### PR TITLE
Follow hal-json links and improve error handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
     "@typescript-eslint",
     "jest"
   ],
+  "ignorePatterns": ["tmp-*.ts"],
   "rules": {
     "semi": [
       "error",

--- a/.github/workflows/full-quality-assurance.yml
+++ b/.github/workflows/full-quality-assurance.yml
@@ -52,8 +52,6 @@ jobs:
       uses: actions/setup-node@v2
     - name: Install npm dependencies
       run: npm ci
-    - name: Build packages
-      run: npm run build
     - name: Run license check
       run: npm run license
 

--- a/.github/workflows/full-quality-assurance.yml
+++ b/.github/workflows/full-quality-assurance.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install npm dependencies
       run: npm ci
     - name: Build packages
-      run: npm ci
+      run: npm run build
     - name: Run tests
       run: npm test
 

--- a/.github/workflows/full-quality-assurance.yml
+++ b/.github/workflows/full-quality-assurance.yml
@@ -52,6 +52,8 @@ jobs:
       uses: actions/setup-node@v2
     - name: Install npm dependencies
       run: npm ci
+    - name: Build packages
+      run: npm run build
     - name: Run license check
       run: npm run license
 

--- a/.github/workflows/full-quality-assurance.yml
+++ b/.github/workflows/full-quality-assurance.yml
@@ -65,6 +65,8 @@ jobs:
       uses: actions/setup-node@v2
     - name: Install npm dependencies
       run: npm ci
+    - name: Build packages
+      run: npm run build
     - name: Generate docs
       run: npm run docs
     - name: Upload docs

--- a/.github/workflows/full-quality-assurance.yml
+++ b/.github/workflows/full-quality-assurance.yml
@@ -24,6 +24,8 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - name: Install npm dependencies
       run: npm ci
+    - name: Build packages
+      run: npm ci
     - name: Run tests
       run: npm test
 
@@ -37,7 +39,7 @@ jobs:
       uses: actions/setup-node@v2
     - name: Install npm dependencies
       run: npm ci
-    - name: Run tests
+    - name: Run linting
       run: npm run lint
 
   license:
@@ -50,7 +52,7 @@ jobs:
       uses: actions/setup-node@v2
     - name: Install npm dependencies
       run: npm ci
-    - name: Run tests
+    - name: Run license check
       run: npm run license
 
   generate-docs:

--- a/jest.json
+++ b/jest.json
@@ -1,18 +1,20 @@
 {
-    "roots": [
-        "packages"
-    ],
-    "testMatch": [
-        "**/*.spec.ts"
-    ],
-    "transform": {
-        "^.+\\.ts$": "ts-jest"
-    },
-    "collectCoverage": true,
-    "collectCoverageFrom": [
-        "**/src/**/*.ts",
-        "!**/src/index.ts"
-    ],
-    "coverageReporters": ["text"]
-
+  "roots": [
+    "packages"
+  ],
+  "testMatch": [
+    "**/*.spec.ts"
+  ],
+  "transform": {
+    "^.+\\.ts$": "ts-jest"
+  },
+  "collectCoverage": true,
+  "collectCoverageFrom": [
+    "**/src/**/*.ts",
+    "!**/src/index.ts",
+    "!**/src/errors.ts"
+  ],
+  "coverageReporters": [
+    "text"
+  ]
 }

--- a/jest.json
+++ b/jest.json
@@ -8,6 +8,11 @@
     "transform": {
         "^.+\\.ts$": "ts-jest"
     },
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+        "**/src/**/*.ts",
+        "!**/src/index.ts"
+    ],
     "coverageReporters": ["text"]
 
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,10 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "independent",
-  "command": {
-    "version": {
-      "message": "Automated task: lerna versioning"
-    }
-  }
+  "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc -b",
     "build:force": "tsc -b --clean && tsc -b",
     "docs": "typedoc",
-    "version": "lerna version --no-push"
+    "version": "lerna version --no-push --no-git-tag-version"
   },
   "pre-commit": [
     "test",

--- a/packages/app-router/src/errors.ts
+++ b/packages/app-router/src/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * RequestSignature is invalid for given appSecret.
+ * @category Error
+ */
+export class InvalidRequestSignatureError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(context: string, public systemBaseUri: string, public tenantId: string, public requestSignature: string) {
+    super(`${context}: RequestSignature '${requestSignature}' can not be validated for '${systemBaseUri}' and '${tenantId}' with given appSecret.`);
+    Object.setPrototypeOf(this, InvalidRequestSignatureError.prototype);
+  }
+}

--- a/packages/app-router/src/generate-request-id/generate-request-id.ts
+++ b/packages/app-router/src/generate-request-id/generate-request-id.ts
@@ -1,7 +1,7 @@
 import { v4 } from "uuid";
 
 /**
- * Returns a unique Version 4 UUID which can be used as requestId.
+ * Generate a unique Version 4 UUID which can be used as requestId.
  * @returns {string}
  *
  * @example ```typescript

--- a/packages/app-router/src/index.ts
+++ b/packages/app-router/src/index.ts
@@ -24,25 +24,26 @@
  */
 
 /**
- * HTTP Header-Name for the systemBaseUri for the tenant.
+ * HTTP Header for the systemBaseUri for the tenant.
  */
 export const DVELOP_SYSTEM_BASE_URI_HEADER = "x-dv-baseuri";
 
 /**
- * HTTP Header-Name for the tenantId for the tenant.
+ * HTTP Header for the tenantId for the tenant.
  */
 export const DVELOP_TENANT_ID_HEADER = "x-dv-tenant-id";
 
 /**
- * HTTP Header-Name for the requestId for the request. Forward this id to make calls trackable throughout d.velop apps.
+ * HTTP Header for the requestId for the request. Forward this id to make calls trackable throughout d.velop apps.
  */
 export const DVELOP_REQUEST_ID_HEADER = "x-dv-request-id";
 
 /**
- * HTTP Header-Name for the requestSignature for the request. **The requestSignature should be validated for every request when recieving calls from the d.velop cloud.
+ * HTTP Header for the requestSignature. **The requestSignature should be validated for every request when recieving calls from the d.velop cloud.
  * Refer to the [d.velop basics tenant header section](https://developer.d-velop.de/dev/en/basics#tenant-header) for more information.**
  */
 export const DVELOP_REQUEST_SIGNATURE_HEADER = "x-dv-sig-1";
 
+export { InvalidRequestSignatureError } from "./errors";
 export { generateRequestId } from "./generate-request-id/generate-request-id";
 export { validateRequestSignature } from "./validate-request-signature/validate-request-signature";

--- a/packages/app-router/src/validate-request-signature/validate-request-signature.spec.ts
+++ b/packages/app-router/src/validate-request-signature/validate-request-signature.spec.ts
@@ -1,3 +1,4 @@
+import { InvalidRequestSignatureError } from "../errors";
 import { validateRequestSignature } from "./validate-request-signature";
 
 describe("validateRequestSignature", () => {
@@ -16,8 +17,8 @@ describe("validateRequestSignature", () => {
       appSecret: "ptuQ0b0BskmLLxXsjjhH9Su8ozTvZl6Z/5/HlaORoRh=",
     }
   ].forEach(testCase => {
-    it(`should return true on: ${JSON.stringify(testCase)})`, () => {
-      expect(validateRequestSignature(testCase.appSecret, testCase.systemBaseUri, testCase.tenantId, testCase.signature)).toBeTruthy();
+    it(`should pass on: ${JSON.stringify(testCase)})`, () => {
+      expect(() => validateRequestSignature(testCase.appSecret, testCase.systemBaseUri, testCase.tenantId, testCase.signature)).not.toThrowError();
     });
   });
 
@@ -59,8 +60,20 @@ describe("validateRequestSignature", () => {
       appSecret: "abcd",
     }
   ].forEach(testCase => {
-    it(`should return false on: ${JSON.stringify(testCase)})`, () => {
-      expect(validateRequestSignature(testCase.appSecret, testCase.systemBaseUri, testCase.tenantId, testCase.signature)).toBeFalsy();
+    it(`should throw InvalidRequestSignatureError on: ${JSON.stringify(testCase)})`, () => {
+
+      let error: InvalidRequestSignatureError;
+      try {
+        validateRequestSignature(testCase.appSecret, testCase.systemBaseUri, testCase.tenantId, testCase.signature);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error instanceof InvalidRequestSignatureError).toBeTruthy();
+      expect(error.message).toContain("Failed to validate requestSignature:");
+      expect(error.systemBaseUri).toEqual(testCase.systemBaseUri);
+      expect(error.tenantId).toEqual(testCase.tenantId);
+      expect(error.requestSignature).toEqual(testCase.signature);
     });
   });
 });

--- a/packages/app-router/src/validate-request-signature/validate-request-signature.ts
+++ b/packages/app-router/src/validate-request-signature/validate-request-signature.ts
@@ -1,26 +1,36 @@
 import * as crypto from "crypto";
+import { InvalidRequestSignatureError } from "../errors";
 
 /**
- * Validates a request-signature against your appSecret.
+ * Validate a request-signature against your appSecret.
+ *
  * **The requestSignature should be validated for every request when recieving calls from the d.velop cloud.
  * Refer to the [d.velop basics tenant header section](https://developer.d-velop.de/dev/en/basics#tenant-header) for more information.**
+ *
  * @param {string} appSecret The secret generated for your app in the cloud-center
  * @param {string} systemBaseUri SystemBaseUri for the tenant (found in 'x-dv-baseuri'-header)
  * @param {string} tenantId ID for the tenant (found in 'x-dv-tenant-id'-header)
  * @param {string} requestSignature ID for the request (found in 'x-dv-sig-1'-header)
- * @returns {boolean}
+ *
+ * @throws {@link InvalidRequestSignatureError} indicates that requestSignature was invalid for given appSecret.
  *
  * @example ```typescript
- * const valid: boolean = validateRequestSignature("ptuQ0b0BskmLLxXsjjhH9Su8ozTvZl6Z/5/HlaORoRg=", "https://header.example.com", "a12be5", "Zjcf28p5aQ6amtbs6s9b9cPyBPdziwUslR2DZqaGUTQ=");
- * console.log(valid); //true
+ * validateRequestSignature("ptuQ0b0BskmLLxXsjjhH9Su8ozTvZl6Z/5/HlaORoRg=", "https://header.example.com", "a12be5", "Zjcf28p5aQ6amtbs6s9b9cPyBPdziwUslR2DZqaGUTQ=");
  * ```
  */
-export function validateRequestSignature(appSecret: string, systemBaseUri: string, tenantId: string, requestSignature: string): boolean {
+export function validateRequestSignature(appSecret: string, systemBaseUri: string, tenantId: string, requestSignature: string): void {
+
+  const errorContext: string = "Failed to validate requestSignature";
+  let validSignature: boolean = false;
+
   try {
     const binarySignatureSecret = Buffer.from(appSecret, "base64");
     const computedHmac = crypto.createHmac("sha256", binarySignatureSecret).update(systemBaseUri + tenantId);
-    return crypto.timingSafeEqual(Buffer.from(requestSignature), Buffer.from(computedHmac.digest("base64")));
+    validSignature = crypto.timingSafeEqual(Buffer.from(requestSignature), Buffer.from(computedHmac.digest("base64")));
   } catch (e) {
-    return false;
+    throw new InvalidRequestSignatureError(errorContext, systemBaseUri, tenantId, requestSignature);
+  }
+  if (!validSignature) {
+    throw new InvalidRequestSignatureError(errorContext, systemBaseUri, tenantId, requestSignature);
   }
 }

--- a/packages/axios-hal-json/README.md
+++ b/packages/axios-hal-json/README.md
@@ -1,0 +1,23 @@
+<div align="center">
+
+  <h1>@dvelop-sdk/app-router</h1>
+
+  <img alt="npm (scoped)" src="https://img.shields.io/npm/v/@dvelop-sdk/axios-hal-json?style=for-the-badge">
+
+  <img alt="npm bundle size (scoped)" src="https://img.shields.io/bundlephobia/min/@dvelop-sdk/axios-hal-json?style=for-the-badge">
+
+  <img alt="GitHub" src="https://img.shields.io/badge/GitHub-dvelop--sdk--node-%23ff0844?logo=github&style=for-the-badge">
+
+  <img alt="license" src="https://img.shields.io/github/license/d-velop/dvelop-sdk-node?style=for-the-badge">
+
+  </br>
+
+  <p>This package contains functionality for the <a href="https://developer.d-velop.de/dev/en/basics">App-Router</a> in the d.velop cloud.</p>
+
+  <a href="https://d-velop.github.io/dvelop-sdk-node/modules/axios-hal-json.html"><strong>Explore the docs »</strong></a>
+  </br>
+  <a href="https://www.npmjs.com/package/@dvelop-sdk/axios-hal-json"><strong>Install via npm »</strong></a>
+  </br>
+  <a href="https://github.com/d-velop/dvelop-sdk-node"><strong>Check us out on GitHub »</strong></a>
+
+</div>

--- a/packages/axios-hal-json/package-lock.json
+++ b/packages/axios-hal-json/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dvelop-sdk/axios-hal-json",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/axios-hal-json/package-lock.json
+++ b/packages/axios-hal-json/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dvelop-sdk/axios-hal-json",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/axios-hal-json/package-lock.json
+++ b/packages/axios-hal-json/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dvelop-sdk/axios-hal-json",
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/axios-hal-json/package-lock.json
+++ b/packages/axios-hal-json/package-lock.json
@@ -1,0 +1,81 @@
+{
+	"name": "@dvelop-sdk/axios-hal-json",
+	"version": "0.0.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@dvelop-sdk/axios-hal-json",
+			"version": "0.0.0",
+			"license": "Apache-2.0",
+			"devDependencies": {
+				"@types/axios": "^0.14.0"
+			}
+		},
+		"node_modules/@types/axios": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+			"integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
+			"deprecated": "This is a stub types definition for axios (https://github.com/mzabriskie/axios). axios provides its own type definitions, so you don't need @types/axios installed!",
+			"dev": true,
+			"dependencies": {
+				"axios": "*"
+			}
+		},
+		"node_modules/axios": {
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+			"dev": true,
+			"dependencies": {
+				"follow-redirects": "^1.10.0"
+			}
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+			"integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		}
+	},
+	"dependencies": {
+		"@types/axios": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+			"integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
+			"dev": true,
+			"requires": {
+				"axios": "*"
+			}
+		},
+		"axios": {
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+			"dev": true,
+			"requires": {
+				"follow-redirects": "^1.10.0"
+			}
+		},
+		"follow-redirects": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+			"integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+			"dev": true
+		}
+	}
+}

--- a/packages/axios-hal-json/package.json
+++ b/packages/axios-hal-json/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dvelop-sdk/axios-hal-json",
   "description": "This package extends axios to handle hal-json specification in the d.velop cloud.",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/axios-hal-json/package.json
+++ b/packages/axios-hal-json/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@dvelop-sdk/axios-hal-json",
+  "description": "This package extends axios to handle hal-json specification in the d.velop cloud.",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "author": "Lennart <lennart.klose@d-velop.de>",
+  "files": [
+    "lib"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/d-velop/dvelop-sdk-node.git"
+  },
+  "bugs": {
+    "url": "https://github.com/d-velop/dvelop-sdk-node/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "license": "license-checker --production --onlyAllow Apache-2.0;MIT;ISC;BSD-2-Clause;BSD-3-Clause"
+  }
+}

--- a/packages/axios-hal-json/package.json
+++ b/packages/axios-hal-json/package.json
@@ -21,5 +21,8 @@
   },
   "scripts": {
     "license": "license-checker --production --onlyAllow Apache-2.0;MIT;ISC;BSD-2-Clause;BSD-3-Clause"
+  },
+  "devDependencies": {
+    "@types/axios": "^0.14.0"
   }
 }

--- a/packages/axios-hal-json/package.json
+++ b/packages/axios-hal-json/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dvelop-sdk/axios-hal-json",
   "description": "This package extends axios to handle hal-json specification in the d.velop cloud.",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/axios-hal-json/package.json
+++ b/packages/axios-hal-json/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dvelop-sdk/axios-hal-json",
   "description": "This package extends axios to handle hal-json specification in the d.velop cloud.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/axios-hal-json/src/errors.ts
+++ b/packages/axios-hal-json/src/errors.ts
@@ -1,0 +1,49 @@
+import { AxiosRequestConfig, AxiosResponse} from "axios";
+
+/**
+ * A request in the follow-chain failed
+ * @category Error
+ */
+export class HalJsonRequestChainError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(public config: AxiosRequestConfig, public originalError: Error) {
+    super(`Request in hal-json chain failed for config: ${JSON.stringify(config)}`);
+    Object.setPrototypeOf(this, HalJsonRequestChainError.prototype);
+  }
+}
+
+/**
+ * A response within the follow-chain does not contain _links.
+ * @category Error
+ */
+export class NoHalJsonLinksInResponseError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(public config: AxiosRequestConfig, public response: AxiosResponse) {
+    super(`No _links found in response: ${JSON.stringify(response.data)}`);
+    Object.setPrototypeOf(this, NoHalJsonLinksInResponseError.prototype);
+  }
+}
+
+/**
+ * A response in the follow-chain does not contain a follow link in _links.
+ * @category Error
+ */
+export class NoHalJsonLinkToFollowError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(public follow: string, public config: AxiosRequestConfig, public response: AxiosResponse) {
+    super(`No href for '${follow}' found in _links: ${JSON.stringify(response.data._links)}`);
+    Object.setPrototypeOf(this, NoHalJsonLinkToFollowError.prototype);
+  }
+}
+
+/**
+ * A link in the follow-chain needs to be templated but no template value was given.
+ * @category Error
+ */
+export class NoHalJsonTemplateValueError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(public template: string, public followUrl: string, public config?: AxiosRequestConfig, public response?: AxiosResponse) {
+    super(`No template value for '${template}'. Needed for url: '${followUrl}`);
+    Object.setPrototypeOf(this, NoHalJsonTemplateValueError.prototype);
+  }
+}

--- a/packages/axios-hal-json/src/errors.ts
+++ b/packages/axios-hal-json/src/errors.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig, AxiosResponse} from "axios";
 
 /**
- * A request in the follow-chain failed
+ * A request in the follow-chain failed.
  * @category Error
  */
 export class HalJsonRequestChainError extends Error {

--- a/packages/axios-hal-json/src/followHalJson/follow-hal-json.spec.ts
+++ b/packages/axios-hal-json/src/followHalJson/follow-hal-json.spec.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
-import { followHalJson, HalJsonRequestChainError, NoHalJsonLinksInResponseError, NoHalJsonLinkToFollowError, NoHalJsonTemplateValueError } from "./follow-hal-json";
+import { HalJsonRequestChainError, NoHalJsonLinkToFollowError, NoHalJsonLinksInResponseError, NoHalJsonTemplateValueError } from "../errors";
+import { followHalJson } from "./follow-hal-json";
 
 jest.mock("axios");
 

--- a/packages/axios-hal-json/src/followHalJson/follow-hal-json.spec.ts
+++ b/packages/axios-hal-json/src/followHalJson/follow-hal-json.spec.ts
@@ -1,0 +1,289 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import { followHalJson, HalJsonRequestChainError, NoHalJsonLinksInResponseError, NoHalJsonLinkToFollowError, NoHalJsonTemplateValueError } from "./follow-hal-json";
+
+jest.mock("axios");
+
+describe("followHalJson", () => {
+
+  [
+    { follows: null, templates: null },
+    { follows: [], templates: null },
+    { follows: null, templates: {} },
+    { follows: [], templates: {} },
+  ].forEach(testCase => {
+    it("should do nothing on empty follows and empty templates", async () => {
+      const result = await followHalJson(testCase);
+      expect(result).toBe(testCase);
+    });
+  });
+
+  describe("on follows", () => {
+
+    const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+    beforeEach(() => {
+      mockedAxios.get.mockReset();
+    });
+
+    it("should follow multiple links", async () => {
+
+      const finalUrl: string = "HiItsMeFinalUrl";
+      const config: AxiosRequestConfig = {
+        baseURL: "HiItsMeBaseUrl",
+        url: "base",
+        follows: ["1", "2", "3", "final"]
+      };
+
+      mockedAxios.request.mockImplementation(config => {
+        switch (config.url) {
+        case "base":
+          return Promise.resolve({ data: { _links: { "1": { href: "one" } } } });
+        case "one":
+          return Promise.resolve({ data: { _links: { "2": { href: "two" } } } });
+        case "two":
+          return Promise.resolve({ data: { _links: { "3": { href: "three" } } } });
+        case "three":
+          return Promise.resolve({ data: { _links: { "final": { href: finalUrl } } } });
+        default:
+          return Promise.reject(new Error());
+        }
+      });
+
+      const resultConfig: AxiosRequestConfig = await followHalJson(config);
+
+      expect(resultConfig.url).toEqual(finalUrl);
+      expect(mockedAxios.request).toBeCalledTimes(4);
+
+    });
+
+    it("should make internal requests with GET and Accept-Header but return original config", async () => {
+      const baseURL: string = "HiItsMeBaseUrl";
+      const headers: any = { someHeader: "HiItsMeHeader" };
+      const finalUrl: string = "HiItsMeFinalUrl";
+      const config: AxiosRequestConfig = {
+        baseURL,
+        headers,
+        method: "POST",
+        url: "base",
+        follows: ["final"]
+      };
+
+      mockedAxios.request.mockResolvedValue({ data: { _links: { "final": { href: finalUrl } } } });
+      const resultConfig: AxiosRequestConfig = await followHalJson(config);
+
+      expect(resultConfig.method).toEqual("POST");
+      expect.objectContaining({
+        baseURL,
+        headers,
+        method: "POST",
+        url: finalUrl
+      });
+
+      expect(mockedAxios.request).toBeCalledWith(expect.objectContaining({
+        baseURL: "HiItsMeBaseUrl",
+        method: "GET",
+        headers: { "Accept": "application/hal+json, application/json" }
+      }));
+    });
+
+    it("throw error on axios error", async () => {
+
+      const config: AxiosRequestConfig = {
+        baseURL: "HiItsMeBaseUrl",
+        url: "base",
+        follows: ["follow"]
+      };
+
+      const error: any = { error: "Some Error" };
+      let expectedError: HalJsonRequestChainError;
+
+      mockedAxios.request.mockRejectedValue(error);
+      try {
+        await followHalJson(config);
+      } catch (e) {
+
+        expectedError = e;
+      }
+
+      expect(expectedError instanceof HalJsonRequestChainError).toBeTruthy();
+      expect(expectedError.config).toBeTruthy();
+      expect(expectedError.originalError).toBe(error);
+    });
+
+    it("throw error if no _links are given", async () => {
+
+      const config: AxiosRequestConfig = {
+        baseURL: "HiItsMeBaseUrl",
+        url: "base",
+        follows: ["follow"]
+      };
+
+      const response: AxiosResponse = { data: {} } as AxiosResponse;
+      let expectedError: NoHalJsonLinksInResponseError;
+
+      mockedAxios.request.mockResolvedValue(response);
+      try {
+        await followHalJson(config);
+      } catch (e) {
+        expectedError = e;
+      }
+      expect(expectedError instanceof NoHalJsonLinksInResponseError).toBeTruthy();
+      expect(expectedError.config).toBeTruthy();
+      expect(expectedError.response).toBe(response);
+    });
+
+    [
+      { data: { _links: {} } },
+      { data: { _links: { follow: "hi" } } }
+    ].forEach(testCase => {
+      it("throw error if no link for follow in _links is given", async () => {
+
+        const config: AxiosRequestConfig = {
+          baseURL: "HiItsMeBaseUrl",
+          url: "base",
+          follows: ["follow"]
+        };
+
+        mockedAxios.request.mockResolvedValue(testCase);
+        let expectedError: NoHalJsonLinkToFollowError;
+
+        try {
+          await followHalJson(config);
+        } catch (e) {
+          expectedError = e;
+        }
+        expect(expectedError instanceof NoHalJsonLinkToFollowError).toBeTruthy();
+        expect(expectedError.follow).toEqual("follow");
+        expect(expectedError.config).toBeTruthy();
+        expect(expectedError.response).toBe(testCase);
+      });
+    });
+  });
+
+  describe("on templates", () => {
+
+    [
+      { url: "No template", templates: {}, expected: "No template" },
+      { url: "No template", templates: { "unneeded": "hi" }, expected: "No template" },
+      { url: "{test}", templates: { "test": "hi" }, expected: "hi" },
+      { url: "{test1}{test2}", templates: { "test1": "hi", "test2": "ho" }, expected: "hiho" },
+      { url: "{test1} {test2}", templates: { "test1": "hi", "test2": "ho" }, expected: "hi ho" },
+      { url: "{test1}{test2}", templates: { "test1": "hi", "test2": "ho" }, expected: "hiho" },
+      { url: "{test1}/{test2}", templates: { "test1": "hi", "test2": "ho" }, expected: "hi/ho" },
+      { url: "test{test1}/{test2}", templates: { "test1": "hi", "test2": "ho" }, expected: "testhi/ho" },
+      { url: "{test1}/{test2}test", templates: { "test1": "hi", "test2": "ho" }, expected: "hi/hotest" },
+      { url: "!@#$%^^&*()_+{!!}", templates: { "!!": "hi" }, expected: "!@#$%^^&*()_+hi" },
+      { url: "{test}", templates: { "test": "hi", "unneeded": "ho" }, expected: "hi" },
+    ].forEach(testCase => {
+
+      const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+      beforeEach(() => {
+        mockedAxios.get.mockReset();
+      });
+
+      it(`should replace templates in "${testCase.url}" to "${testCase.expected} for initial templating"`, async () => {
+
+        const result: AxiosRequestConfig = await followHalJson({
+          url: testCase.url,
+          templates: testCase.templates
+        });
+
+        expect(result.url).toEqual(testCase.expected);
+      });
+
+      it(`should replace templates in "${testCase.url}" to "${testCase.expected} for response templating"`, async () => {
+
+        const response: AxiosResponse = {
+          data: {
+            _links: {
+              follow: {
+                href: testCase.url
+              }
+            }
+          }
+        } as AxiosResponse;
+
+        mockedAxios.request.mockResolvedValue(response);
+
+        const result: AxiosRequestConfig = await followHalJson({
+          follows: ["follow"],
+          templates: testCase.templates
+        });
+        expect(result.url).toEqual(testCase.expected);
+      });
+
+
+    });
+
+    [
+      { url: "a{B}c{D}e", templates: { D: "d" }, failTemplate: "{B}", failUrl: "a{B}c{D}e" },
+      { url: "a{B}c{D}e", templates: {}, failTemplate: "{B}", failUrl: "a{B}c{D}e" },
+      { url: "a{B}c{D}e", templates: null, failTemplate: "{B}", failUrl: "a{B}c{D}e" },
+      { url: "a{B}c{D}e", templates: undefined, failTemplate: "{B}", failUrl: "a{B}c{D}e" },
+      { url: "a{B}c{D}e", failTemplate: "{B}", failUrl: "a{B}c{D}e" },
+      { url: "a{B}c{D}e", templates: { B: "b" }, failTemplate: "{D}", failUrl: "abc{D}e" }
+    ].forEach(testCase => {
+
+      const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+      beforeEach(() => {
+        mockedAxios.get.mockReset();
+      });
+
+
+      it("should throw NoHalJsonTemplateValueError if missing template for response templating", async () => {
+
+        const config: AxiosRequestConfig = {
+          baseURL: "HiItsMeBaseUrl",
+          url: testCase.url,
+          templates: testCase.templates
+        };
+
+        let expectedError: NoHalJsonTemplateValueError;
+
+        try {
+          await followHalJson(config);
+        } catch (e) {
+          expectedError = e;
+        }
+        expect(expectedError instanceof NoHalJsonTemplateValueError).toBeTruthy();
+        expect(expectedError.template).toEqual(testCase.failTemplate);
+        expect(expectedError.followUrl).toEqual(testCase.failUrl);
+        expect(expectedError.config).toEqual(config);
+      });
+
+      it("should throw NoHalJsonTemplateValueError if missing template for initial templating", async () => {
+
+        const config: AxiosRequestConfig = {
+          follows: ["follow"],
+          templates: testCase.templates
+        };
+
+        const response: AxiosResponse = {
+          data: {
+            _links: {
+              follow: {
+                href: testCase.url
+              }
+            }
+          }
+        } as AxiosResponse;
+
+        mockedAxios.request.mockResolvedValue(response);
+        let expectedError: NoHalJsonTemplateValueError;
+
+        try {
+          await followHalJson(config);
+        } catch (e) {
+          expectedError = e;
+        }
+
+        expect(expectedError instanceof NoHalJsonTemplateValueError).toBeTruthy();
+        expect(expectedError.template).toEqual(testCase.failTemplate);
+        expect(expectedError.followUrl).toEqual(testCase.failUrl);
+        expect(expectedError.config).toBeTruthy();
+      });
+    });
+  });
+});

--- a/packages/axios-hal-json/src/followHalJson/follow-hal-json.ts
+++ b/packages/axios-hal-json/src/followHalJson/follow-hal-json.ts
@@ -1,53 +1,7 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import { HalJsonRequestChainError, NoHalJsonLinkToFollowError, NoHalJsonLinksInResponseError, NoHalJsonTemplateValueError } from "../errors";
 import "../index";
 
-/**
- * A request in the follow-chain failed
- * @category Error
- */
-export class HalJsonRequestChainError extends Error {
-  // eslint-disable-next-line no-unused-vars
-  constructor(public config: AxiosRequestConfig, public originalError: Error) {
-    super(`Request in hal-json chain failed for config: ${JSON.stringify(config)}`);
-    Object.setPrototypeOf(this, HalJsonRequestChainError.prototype);
-  }
-}
-
-/**
- * A response within the follow-chain does not contain _links.
- * @category Error
- */
-export class NoHalJsonLinksInResponseError extends Error {
-  // eslint-disable-next-line no-unused-vars
-  constructor(public config: AxiosRequestConfig, public response: AxiosResponse) {
-    super(`No _links found in response: ${JSON.stringify(response.data)}`);
-    Object.setPrototypeOf(this, NoHalJsonLinksInResponseError.prototype);
-  }
-}
-
-/**
- * A response in the follow-chain does not contain a follow link in _links.
- * @category Error
- */
-export class NoHalJsonLinkToFollowError extends Error {
-  // eslint-disable-next-line no-unused-vars
-  constructor(public follow: string, public config: AxiosRequestConfig, public response: AxiosResponse) {
-    super(`No href for '${follow}' found in _links: ${JSON.stringify(response.data._links)}`);
-    Object.setPrototypeOf(this, NoHalJsonLinkToFollowError.prototype);
-  }
-}
-
-/**
- * A link in the follow-chain needs to be templated but no template value was given.
- * @category Error
- */
-export class NoHalJsonTemplateValueError extends Error {
-  // eslint-disable-next-line no-unused-vars
-  constructor(public template: string, public followUrl: string, public config?: AxiosRequestConfig, public response?: AxiosResponse) {
-    super(`No template value for '${template}'. Needed for url: '${followUrl}`);
-    Object.setPrototypeOf(this, NoHalJsonTemplateValueError.prototype);
-  }
-}
 
 /**
  * This method can be registered as a [axios interceptor]{@link https://github.com/axios/axios#interceptors} to add hal-json follow behaviour. After registering just add ```follows``` and ```templates``` to your [request-config]{@link https://github.com/axios/axios#request-config}. To work with relative hal-json links use the ```baseUri``` and ```uri``` property.

--- a/packages/axios-hal-json/src/followHalJson/follow-hal-json.ts
+++ b/packages/axios-hal-json/src/followHalJson/follow-hal-json.ts
@@ -1,0 +1,162 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import "../index";
+
+/**
+ * A request in the follow-chain failed
+ * @category Error
+ */
+export class HalJsonRequestChainError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(public config: AxiosRequestConfig, public originalError: Error) {
+    super(`Request in hal-json chain failed for config: ${JSON.stringify(config)}`);
+    Object.setPrototypeOf(this, HalJsonRequestChainError.prototype);
+  }
+}
+
+/**
+ * A response within the follow-chain does not contain _links.
+ * @category Error
+ */
+export class NoHalJsonLinksInResponseError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(public config: AxiosRequestConfig, public response: AxiosResponse) {
+    super(`No _links found in response: ${JSON.stringify(response.data)}`);
+    Object.setPrototypeOf(this, NoHalJsonLinksInResponseError.prototype);
+  }
+}
+
+/**
+ * A response in the follow-chain does not contain a follow link in _links.
+ * @category Error
+ */
+export class NoHalJsonLinkToFollowError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(public follow: string, public config: AxiosRequestConfig, public response: AxiosResponse) {
+    super(`No href for '${follow}' found in _links: ${JSON.stringify(response.data._links)}`);
+    Object.setPrototypeOf(this, NoHalJsonLinkToFollowError.prototype);
+  }
+}
+
+/**
+ * A link in the follow-chain needs to be templated but no template value was given.
+ * @category Error
+ */
+export class NoHalJsonTemplateValueError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(public template: string, public followUrl: string, public config?: AxiosRequestConfig, public response?: AxiosResponse) {
+    super(`No template value for '${template}'. Needed for url: '${followUrl}`);
+    Object.setPrototypeOf(this, NoHalJsonTemplateValueError.prototype);
+  }
+}
+
+/**
+ * This method can be registered as a [axios interceptor]{@link https://github.com/axios/axios#interceptors} to add hal-json follow behaviour. After registering just add ```follows``` and ```templates``` to your [request-config]{@link https://github.com/axios/axios#request-config}. To work with relative hal-json links use the ```baseUri``` and ```uri``` property.
+ *
+ * The original axios config is preserved except the ```url``` property. During hal-json request the method is set to 'GET' and the Accept-Header is set to 'application/hal+json, application/json'.
+ *
+ * @throws [[HalJsonRequestChainError]] indicates that a request in the follow-chain failed.
+ * @throws [[NoHalJsonLinksInResponseError]] indicates that a response within the follow-chain does not contain _links.
+ * @throws [[NoHalJsonLinkToFollowError]] indicates that a response in the follow-chain does not contain a follow link in _links.
+ * @throws [[NoHalJsonTemplateValueError]] indicates that a link in the follow-chain needs to be templated but no template value was given.
+ *
+ * @param {AxiosRequestConfig} config Config object for axios request.
+ * @returns {AxiosRequestConfig} Config object for axios request. The ```url``` property will contain the final url.
+ *
+ * @example ```typescript
+ *
+ * import axios from "axios";
+ * import { followHalJson } from "@dvelop-sdk/axios-hal-json";
+ *
+ * axios.interceptors.request.use(followHalJson);
+ *
+ * const response: Axiosresponse = axios({
+ *   baseUrl: "https://abstergo-industries.d-velop.cloud",
+ *   uri: "/dms",
+ *   follows: ["repo"],
+ *   templates: {repositoryid: "e2f7b638-1fff-4796-90d0-25205f57a582"}
+ * });
+ * ```
+ */
+export async function followHalJson(config: AxiosRequestConfig): Promise<AxiosRequestConfig> {
+
+  if (config.url) {
+    try {
+      config.url = templateUrl(config.url, config.templates);
+    } catch (e) {
+      e.config = config;
+      throw e;
+    }
+  }
+
+  if (!config.follows || config.follows.length === 0) {
+    return config;
+  }
+
+  for (let f of config.follows) {
+    config.url = await getFollowUrl({ ...config }, f);
+  }
+  return config;
+}
+
+async function getFollowUrl(config: AxiosRequestConfig, follow: string): Promise<string> {
+
+  if (!config.headers) {
+    config.headers = {};
+  }
+
+  config.method = "GET";
+  config.headers["Accept"] = "application/hal+json, application/json";
+  config.follows = [];
+
+  let response: AxiosResponse;
+
+  try {
+    response = await axios.request(config);
+  } catch (e) {
+    throw new HalJsonRequestChainError(config, e);
+  }
+
+  if (!response.data._links) {
+    throw new NoHalJsonLinksInResponseError(config, response);
+  }
+
+  if (!response.data._links[follow] || !response.data._links[follow].href) {
+    throw new NoHalJsonLinkToFollowError(follow, config, response);
+  }
+
+  let followUrl: string = response.data._links[follow].href;
+
+  try {
+    followUrl = templateUrl(followUrl, config.templates);
+  } catch (e) {
+    e.config = config;
+    e.response = response;
+    throw e;
+  }
+
+  return followUrl;
+}
+
+function templateUrl(url: string, templates: { [key: string]: string } | undefined): string {
+
+  let matches: RegExpExecArray | null;
+
+  while ((matches = /{(.*?)}/g.exec(url)) !== null) {
+
+    const template: string = matches[0];
+
+    if (!templates || Object.keys(templates).length === 0) {
+      throw new NoHalJsonTemplateValueError(template, url);
+    }
+
+    const value: string = templates[template.slice(1, -1)];
+
+    if (!value) {
+      throw new NoHalJsonTemplateValueError(template, url);
+    }
+
+    url = url.replace(template, value);
+  }
+
+  return url;
+}

--- a/packages/axios-hal-json/src/followHalJson/follow-hal-json.ts
+++ b/packages/axios-hal-json/src/followHalJson/follow-hal-json.ts
@@ -8,14 +8,14 @@ import "../index";
  *
  * The original axios config is preserved except the ```url``` property. During hal-json request the method is set to 'GET' and the Accept-Header is set to 'application/hal+json, application/json'.
  *
- * @throws [[HalJsonRequestChainError]] indicates that a request in the follow-chain failed.
- * @throws [[NoHalJsonLinksInResponseError]] indicates that a response within the follow-chain does not contain _links.
- * @throws [[NoHalJsonLinkToFollowError]] indicates that a response in the follow-chain does not contain a follow link in _links.
- * @throws [[NoHalJsonTemplateValueError]] indicates that a link in the follow-chain needs to be templated but no template value was given.
+ * @param {AxiosRequestConfig} config Config object for axios request
+ * @returns {AxiosRequestConfig} Config object for axios request. The ```url``` property will contain the final url
  *
- * @param {AxiosRequestConfig} config Config object for axios request.
- * @returns {AxiosRequestConfig} Config object for axios request. The ```url``` property will contain the final url.
- *
+ * @throws {@link HalJsonRequestChainError} indicates that a request in the follow-chain failed.
+ * @throws {@link NoHalJsonLinksInResponseError} indicates that a response within the follow-chain does not contain _links.
+ * @throws {@link NoHalJsonLinkToFollowError} indicates that a response in the follow-chain does not contain a follow link in _links.
+ * @throws {@link NoHalJsonTemplateValueError} indicates that a link in the follow-chain needs to be templated but no template value was given.
+
  * @example ```typescript
  *
  * import axios from "axios";

--- a/packages/axios-hal-json/src/index.ts
+++ b/packages/axios-hal-json/src/index.ts
@@ -1,0 +1,27 @@
+/**
+ * <div align="center">
+
+    <h1>@dvelop-sdk/app-router</h1>
+
+    <img alt="npm (scoped)" src="https://img.shields.io/npm/v/@dvelop-sdk/axios-hal-json?style=for-the-badge">
+
+    <img alt="npm bundle size (scoped)" src="https://img.shields.io/bundlephobia/min/@dvelop-sdk/axios-hal-json?style=for-the-badge">
+
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-dvelop--sdk--node-%23ff0844?logo=github&style=for-the-badge">
+
+    <img alt="license" src="https://img.shields.io/github/license/d-velop/dvelop-sdk-node?style=for-the-badge">
+
+    </br>
+
+    <p>This package contains functionality for the <a href="https://developer.d-velop.de/dev/en/basics">App-Router</a> in the d.velop cloud.</p>
+
+    <a href="https://d-velop.github.io/dvelop-sdk-node/modules/axios-hal-json.html"><strong>Explore the docs »</strong></a>
+    </br>
+    <a href="https://www.npmjs.com/package/@dvelop-sdk/axios-hal-json"><strong>Install via npm »</strong></a>
+    </br>
+    <a href="https://github.com/d-velop/dvelop-sdk-node"><strong>Check us out on GitHub »</strong></a>
+
+ * </div >
+ * @module axios-hal-json
+ */
+

--- a/packages/axios-hal-json/src/index.ts
+++ b/packages/axios-hal-json/src/index.ts
@@ -33,4 +33,5 @@ declare module "axios" {
   }
 }
 
-export { followHalJson, HalJsonRequestChainError, NoHalJsonLinksInResponseError, NoHalJsonLinkToFollowError, NoHalJsonTemplateValueError } from "./followHalJson/follow-hal-json";
+export { HalJsonRequestChainError, NoHalJsonLinksInResponseError, NoHalJsonLinkToFollowError, NoHalJsonTemplateValueError} from "./errors";
+export { followHalJson } from "./followHalJson/follow-hal-json";

--- a/packages/axios-hal-json/src/index.ts
+++ b/packages/axios-hal-json/src/index.ts
@@ -25,3 +25,12 @@
  * @module axios-hal-json
  */
 
+import "axios";
+
+declare module "axios" {
+  // eslint-disable-next-line no-unused-vars
+  interface AxiosRequestConfig {
+    follows?: string[];
+    templates?: { [key: string]: string }
+  }
+}

--- a/packages/axios-hal-json/src/index.ts
+++ b/packages/axios-hal-json/src/index.ts
@@ -25,8 +25,6 @@
  * @module axios-hal-json
  */
 
-import "axios";
-
 declare module "axios" {
   // eslint-disable-next-line no-unused-vars
   interface AxiosRequestConfig {
@@ -34,3 +32,5 @@ declare module "axios" {
     templates?: { [key: string]: string }
   }
 }
+
+export { followHalJson, HalJsonRequestChainError, NoHalJsonLinksInResponseError, NoHalJsonLinkToFollowError, NoHalJsonTemplateValueError } from "./followHalJson/follow-hal-json";

--- a/packages/axios-hal-json/tsconfig.json
+++ b/packages/axios-hal-json/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "outDir": "lib",                    /* Redirect output structure to the directory. */
+    "rootDir": "src"                    /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.spec.ts"]
+}

--- a/packages/identityprovider/package-lock.json
+++ b/packages/identityprovider/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dvelop-sdk/identityprovider",
-	"version": "1.0.4",
+	"version": "2.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/identityprovider/package.json
+++ b/packages/identityprovider/package.json
@@ -23,6 +23,7 @@
     "license": "license-checker --production --onlyAllow Apache-2.0;MIT;ISC;BSD-2-Clause;BSD-3-Clause"
   },
   "dependencies": {
+    "@dvelop-sdk/axios-hal-json": "^1.0.0",
     "axios": "^0.21.1"
   }
 }

--- a/packages/identityprovider/package.json
+++ b/packages/identityprovider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dvelop-sdk/identityprovider",
   "description": "This package contains functionality for the Identityprovider-App in the d.velop cloud.",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -23,7 +23,7 @@
     "license": "license-checker --production --onlyAllow Apache-2.0;MIT;ISC;BSD-2-Clause;BSD-3-Clause"
   },
   "dependencies": {
-    "@dvelop-sdk/axios-hal-json": "^1.0.0",
+    "@dvelop-sdk/axios-hal-json": "^1.0.1",
     "axios": "^0.21.1"
   }
 }

--- a/packages/identityprovider/src/errors.ts
+++ b/packages/identityprovider/src/errors.ts
@@ -1,0 +1,38 @@
+import { AxiosResponse } from "axios";
+
+/**
+ * Invalid authSessionId or no authSessionId transferred.
+ * @category Error
+ */
+export class UnauthorizedError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(context: string, public response: AxiosResponse) {
+    super(`${context}: Invalid authSessionId or no authSessionId transferred.`);
+    Object.setPrototypeOf(this, UnauthorizedError.prototype);
+  }
+}
+
+/**
+ * Valid authSessionId for an external user but external validation was set to false.
+ * @category Error
+ */
+export class ForbiddenError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(context: string, public response: AxiosResponse) {
+    super(`${context}: Valid authSessionId for an external user but external validation was set to false.`);
+    Object.setPrototypeOf(this, ForbiddenError.prototype);
+  }
+}
+
+
+/**
+ * Valid token for a deleted user.
+ * @category Error
+ */
+export class NotFoundError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(context: string, public response: AxiosResponse) {
+    super(`${context}: Valid authSessionId for a deleted user.`);
+    Object.setPrototypeOf(this, NotFoundError.prototype);
+  }
+}

--- a/packages/identityprovider/src/get-auth-session/auth-session.ts
+++ b/packages/identityprovider/src/get-auth-session/auth-session.ts
@@ -1,5 +1,6 @@
 /**
  * A valid authentication-session for the d.velop cloud. Refer to the [documentation](https://developer.d-velop.de/documentation/idpapi/en/identityprovider-app-201523580.html#validating-the-login) for further information.
+ *
  * @property {string} id Id for the AuthSession. This key will validate your requests. **The AuthSessionId should be kept secret and never be publicly available**
  * @property {Date} expire Date-Object for the point in time at which the AuthSessionId will no longer be valid.
  */

--- a/packages/identityprovider/src/get-auth-session/get-auth-session.spec.ts
+++ b/packages/identityprovider/src/get-auth-session/get-auth-session.spec.ts
@@ -1,9 +1,11 @@
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
+import { UnauthorizedError } from "../errors";
+import { AuthSession } from "./auth-session";
 import { getAuthSession, AuthSessionDto } from "./get-auth-session";
 
 jest.mock("axios");
 
-describe("validateAuthsessionId", () => {
+describe("getAuthSession", () => {
 
   const mockedAxios = axios as jest.Mocked<typeof axios>;
 
@@ -11,44 +13,125 @@ describe("validateAuthsessionId", () => {
     mockedAxios.get.mockReset();
   });
 
-  it("should make GET with correct URI", async () => {
+  describe("axios-params", () => {
 
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-    const data: AuthSessionDto = { AuthSessionId: "HiItsMeAuthSessionId", Expire: "1992-02-16T13:29:21.8163512Z" };
-    mockedAxios.get.mockResolvedValue({ data });
+    beforeEach(() => {
+      mockedAxios.get.mockResolvedValue({
+        data: {
+          AuthSessionId: "HiItsMeAuthSessionId",
+          Expire: "1992-02-16T16:11:03.8019256Z"
+        }
+      });
+    });
 
-    await getAuthSession(systemBaseUri, "HiItsMeApiKey");
+    it("should send GET", async () => {
+      await getAuthSession("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
 
-    expect(mockedAxios.get).toBeCalledWith(`${systemBaseUri}/identityprovider/login`, expect.any(Object));
+    it("should send to /identityprovider", async () => {
+      await getAuthSession("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      expect(mockedAxios.get).toHaveBeenCalledWith("/identityprovider", expect.any(Object));
+    });
+
+    it("should send with systemBaseUri as BaseURL", async () => {
+      const systemBaseUri: string = "HiItsMeSystemBaseUri";
+      await getAuthSession(systemBaseUri, "HiItsMeAuthSessionId");
+      expect(mockedAxios.get).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+        baseURL: systemBaseUri
+      }));
+    });
+
+    it("should send with authSessionId as Authorization-Header", async () => {
+      const authSessionId: string = "HiItsMeAuthSessionId";
+      await getAuthSession("HiItsMeSystemBaseUri", authSessionId);
+      expect(mockedAxios.get).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+        headers: expect.objectContaining({ "Authorization": `Bearer ${authSessionId}` })
+      }));
+    });
+
+    it("should send with follows: login", async () => {
+      await getAuthSession("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      expect(mockedAxios.get).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+        follows: ["login"]
+      }));
+    });
   });
 
-  it("should make GET with correct headers", async () => {
+  describe("response", () => {
 
-    const apiKey = "HiItsMeApiKey";
-    const data: AuthSessionDto = { AuthSessionId: "HiItsMeAuthSessionId", Expire: "1992-02-16T13:29:21.8163512Z" };
-    mockedAxios.get.mockResolvedValue({ data });
+    it("should return AuthSessionId", async () => {
 
-    await getAuthSession("HiItsMeSystemBaseUri", apiKey);
+      const authSessionDto: AuthSessionDto = {
+        AuthSessionId: "HiItsMeAuthSessionId",
+        Expire: "1992-02-16T16:11:03.8019256Z"
+      };
 
-    expect(mockedAxios.get).toBeCalledWith(expect.any(String), { headers: { "Authorization": `Bearer ${apiKey}` } });
+      mockedAxios.get.mockResolvedValue({
+        data: authSessionDto
+      });
+
+      const result: AuthSession = await getAuthSession("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      expect(result.id).toEqual(authSessionDto.AuthSessionId);
+    });
+
+    it("should return parsed expireDate", async () => {
+
+      const authSessionDto: AuthSessionDto = {
+        AuthSessionId: "HiItsMeAuthSessionId",
+        Expire: "1992-02-16T16:11:03.8019256Z"
+      };
+
+      mockedAxios.get.mockResolvedValue({
+        data: authSessionDto
+      });
+
+      const result: AuthSession = await getAuthSession("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      expect(result.expire instanceof Date).toBeTruthy();
+      expect(result.expire.getTime()).toEqual(new Date(authSessionDto.Expire).getTime());
+    });
   });
 
-  it("should return response.data object", async () => {
+  describe("errors", () => {
 
-    const data: AuthSessionDto = { AuthSessionId: "HiItsMeAuthSessionId", Expire: "1992-02-16T13:29:21.8163512Z" };
-    mockedAxios.get.mockResolvedValue({ data });
+    it("should throw UnauthorizesError on status 401", async () => {
 
-    const authsession = await getAuthSession("HiItsMeSystemBaseUri", "HiItsMeApiKey");
+      const response: AxiosResponse = {
+        status: 401,
+      } as AxiosResponse;
 
-    expect(authsession.id).toEqual(data.AuthSessionId);
-    expect(authsession.expire).toEqual(new Date(data.Expire));
-  });
+      mockedAxios.get.mockRejectedValue({ response });
 
-  it("should throw error on http-error", async () => {
+      let error: UnauthorizedError;
+      try {
+        await getAuthSession("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      } catch (e) {
+        error = e;
+      }
 
-    const error: Error = new Error("HiItsMeError");
-    mockedAxios.get.mockRejectedValue(error);
+      expect(error instanceof UnauthorizedError).toBeTruthy();
+      expect(error.message).toContain("Failed to get authSession:");
+      expect(error.response).toEqual(response);
+    });
 
-    await expect(getAuthSession("HiItsMeSystemBaseUri", "HiItsMeApiKey")).rejects.toThrowError(`Failed to get AuthSession for given API-Key.\n${error}`);
+    it("should throw UnknownErrors", async () => {
+
+      const errorString: string = "HiItsMeError";
+      const error: Error = new Error(errorString);
+      mockedAxios.get.mockImplementation(() => {
+        throw error;
+      });
+
+      let resultError: Error;
+      try {
+        await getAuthSession("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      } catch (e) {
+        resultError = e;
+      }
+
+      expect(resultError).toBe(error);
+      expect(resultError.message).toContain(errorString);
+      expect(resultError.message).toContain("Failed to get authSession:");
+    });
   });
 });

--- a/packages/identityprovider/src/get-auth-session/get-auth-session.ts
+++ b/packages/identityprovider/src/get-auth-session/get-auth-session.ts
@@ -11,13 +11,18 @@ export interface AuthSessionDto {
 
 /**
  * Returns an [AuthSession]{@link AuthSession} based on an API-Key.
- * **The AuthSessionId should be kept secret and never be publicly available**
- * @param {string} systemBaseUri SystemBaseUri for the tenant.
- * @param {string} apiKey API-Key provided by the d.velop cloud.
+ *
+ * **The AuthSessionId should be kept secret and never be publicly available.**
+ *
+ * @param {string} systemBaseUri SystemBaseUri for the tenant
+ * @param {string} apiKey API-Key provided by the d.velop cloud
  * @returns {string}
  *
+ * @throws {@link UnauthorizedError} indicates an invalid authSessionId or no authSessionId was sent.
+ *
  * @example ```typescript
- * const authSession: AuthSession = await getAuthSession("https://dharma-initiative.d-velop.cloud", "<API_KEY>");
+ *
+ * const authSession: AuthSession = await getAuthSession("https://monster-ag.d-velop.cloud", "<API_KEY>");
  * console.log(authSession.id); //a valid authSessionId
  * console.log('still valid:', authSession.expire.getTime() > new Date().getTime()); //still valid: true
  * ```

--- a/packages/identityprovider/src/get-login-redirection-uri/get-login-redirection-uri.ts
+++ b/packages/identityprovider/src/get-login-redirection-uri/get-login-redirection-uri.ts
@@ -1,6 +1,7 @@
 /**
  * Returns the URI a request should be redirected to in case it does not contain a valid authSessionId. Redirected requests will display a HTML Login for users to authenticate.
- * @param {string} successUri The URI the request should be redirected to after a successful login.
+ *
+ * @param {string} successUri The URI the request should be redirected to after a successful login
  * @returns {string}
  *
  * @example ```typescript

--- a/packages/identityprovider/src/index.ts
+++ b/packages/identityprovider/src/index.ts
@@ -22,6 +22,7 @@
  * </div>
  * @module identityprovider
  */
+export { UnauthorizedError, ForbiddenError, NotFoundError } from "./errors";
 export { AuthSession } from "./get-auth-session/auth-session";
 export { getAuthSession } from "./get-auth-session/get-auth-session";
 export { ScimUser } from "./validate-auth-session-id/scim-user";

--- a/packages/identityprovider/src/validate-auth-session-id/scim-user.ts
+++ b/packages/identityprovider/src/validate-auth-session-id/scim-user.ts
@@ -10,22 +10,22 @@
  */
 
 export interface ScimUser {
-  id: string;
-  userName: string;
-  name: {
-    familyName: string;
-    givenName: string;
+  id?: string;
+  userName?: string;
+  name?: {
+    familyName?: string;
+    givenName?: string;
   };
-  displayName: string;
-  emails: {
-    value: string;
+  displayName?: string;
+  emails?: {
+    value?: string;
   }[];
-  groups: {
-    value: string;
-    display: string;
+  groups?: {
+    value?: string;
+    display?: string;
   }[];
-  photos: {
-    value: string;
-    type: string;
+  photos?: {
+    value?: string;
+    type?: string;
   }[];
 }

--- a/packages/identityprovider/src/validate-auth-session-id/validate-auth-session-id.spec.ts
+++ b/packages/identityprovider/src/validate-auth-session-id/validate-auth-session-id.spec.ts
@@ -1,9 +1,11 @@
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
+import { ForbiddenError, NotFoundError, UnauthorizedError } from "../errors";
+import { ScimUser } from "./scim-user";
 import { validateAuthSessionId } from "./validate-auth-session-id";
 
 jest.mock("axios");
 
-describe("validateAuthsessionId", () => {
+describe("validateAuthSessionId", () => {
 
   const mockedAxios = axios as jest.Mocked<typeof axios>;
 
@@ -11,42 +13,146 @@ describe("validateAuthsessionId", () => {
     mockedAxios.get.mockReset();
   });
 
-  it("should make GET with correct URI", async () => {
+  describe("axios-params", () => {
 
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-    mockedAxios.get.mockResolvedValue({});
+    beforeEach(() => {
+      mockedAxios.get.mockResolvedValue({});
+    });
 
-    await validateAuthSessionId(systemBaseUri, "HiItsMeAuthSessionId");
+    it("should send GET", async () => {
+      await validateAuthSessionId("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
 
-    expect(mockedAxios.get).toBeCalledWith(`${systemBaseUri}/identityprovider/validate`, expect.any(Object));
+    it("should send to /identityprovider", async () => {
+      await validateAuthSessionId("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      expect(mockedAxios.get).toHaveBeenCalledWith("/identityprovider", expect.any(Object));
+    });
+
+    it("should send with systemBaseUri as BaseURL", async () => {
+      const systemBaseUri: string = "HiItsMeSystemBaseUri";
+      await validateAuthSessionId(systemBaseUri, "HiItsMeAuthSessionId");
+      expect(mockedAxios.get).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+        baseURL: systemBaseUri
+      }));
+    });
+
+    it("should send with authSessionId as Authorization-Header", async () => {
+      const authSessionId: string = "HiItsMeAuthSessionId";
+      await validateAuthSessionId("HiItsMeSystemBaseUri", authSessionId);
+      expect(mockedAxios.get).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+        headers: expect.objectContaining({ "Authorization": `Bearer ${authSessionId}` })
+      }));
+    });
+
+    it("should send with follows: validate", async () => {
+      await validateAuthSessionId("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      expect(mockedAxios.get).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+        follows: ["validate"]
+      }));
+    });
   });
 
-  it("should make GET with correct headers", async () => {
+  describe("response", () => {
 
-    const authSessionId = "HiItsMeAuthSessionId";
-    mockedAxios.get.mockResolvedValue({});
+    it("should return user", async () => {
 
-    await validateAuthSessionId("HiItsMeSystemBaseUri", authSessionId);
+      const user: ScimUser = {
+        name: {
+          familyName: "HiItsMeFamilyName",
+          givenName: "HiItsMeGivenName"
+        },
+      };
 
-    expect(mockedAxios.get).toBeCalledWith(expect.any(String), { headers: { "Authorization": `Bearer ${authSessionId}` } });
+      mockedAxios.get.mockResolvedValue({
+        data: user
+      });
+
+      const result: ScimUser = await validateAuthSessionId("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      expect(result).toEqual(expect.objectContaining(user));
+    });
   });
 
-  it("should return response.data object", async () => {
+  describe("errors", () => {
 
-    const data = { hi: "ItsMeDataObject" };
-    mockedAxios.get.mockResolvedValue({ data });
+    it("should throw UnauthorizesError on status 401", async () => {
 
-    const user = await validateAuthSessionId("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      const response: AxiosResponse = {
+        status: 401,
+      } as AxiosResponse;
 
-    expect(user).toEqual(data);
-  });
+      mockedAxios.get.mockRejectedValue({ response });
 
-  it("should throw error on http-error", async () => {
+      let error: UnauthorizedError;
+      try {
+        await validateAuthSessionId("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      } catch (e) {
+        error = e;
+      }
 
-    const error: Error = new Error("HiItsMeError");
-    mockedAxios.get.mockRejectedValue(error);
+      expect(error instanceof UnauthorizedError).toBeTruthy();
+      expect(error.message).toContain("Failed to validate authSessionId:");
+      expect(error.response).toEqual(response);
+    });
 
-    await expect(validateAuthSessionId("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId")).rejects.toThrowError(`Failed to validate AuthSessionId.\n${error}`);
+    it("should throw ForbiddenError on status 403", async () => {
+
+      const response: AxiosResponse = {
+        status: 403,
+      } as AxiosResponse;
+
+      mockedAxios.get.mockRejectedValue({ response });
+
+      let error: ForbiddenError;
+      try {
+        await validateAuthSessionId("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error instanceof ForbiddenError).toBeTruthy();
+      expect(error.message).toContain("Failed to validate authSessionId:");
+      expect(error.response).toEqual(response);
+    });
+
+    it("should throw NotFoundError on status 404", async () => {
+
+      const response: AxiosResponse = {
+        status: 404,
+      } as AxiosResponse;
+
+      mockedAxios.get.mockRejectedValue({ response });
+
+      let error: NotFoundError;
+      try {
+        await validateAuthSessionId("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error instanceof NotFoundError).toBeTruthy();
+      expect(error.message).toContain("Failed to validate authSessionId:");
+      expect(error.response).toEqual(response);
+    });
+
+    it("should throw UnknownErrors", async () => {
+
+      const errorString: string = "HiItsMeError";
+      const error: Error = new Error(errorString);
+      mockedAxios.get.mockImplementation(() => {
+        throw error;
+      });
+
+      let resultError: Error;
+      try {
+        await validateAuthSessionId("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId");
+      } catch (e) {
+        resultError = e;
+      }
+
+      expect(resultError).toBe(error);
+      expect(resultError.message).toContain(errorString);
+      expect(resultError.message).toContain("Failed to validate authSessionId:");
+    });
   });
 });
- 

--- a/packages/identityprovider/src/validate-auth-session-id/validate-auth-session-id.ts
+++ b/packages/identityprovider/src/validate-auth-session-id/validate-auth-session-id.ts
@@ -7,13 +7,13 @@ axios.interceptors.request.use(followHalJson);
 /**
  * Validates an AuthSessionId and returns a [ScimUser]{@link ScimUser}
  *
- * @throws [[UnauthorizedError]] indicates that an invalid or no authSessionId was sent.
- * @throws [[ForbiddenError]] indicates that a valid authSessionId for an external user was sent but external validation was set to false.
- * @throws [[NotFoundError]] indicates that a valid token for a deleted user was sent.
- *
- * @param {string} systemBaseUri SystemBaseUri for the tenant.
- * @param {string} authSessionId AuthSessionId which should be validated.
+ * @param {string} systemBaseUri SystemBaseUri for the tenant
+ * @param {string} authSessionId AuthSessionId which should be validated
  * @returns {ScimUser}
+ *
+ * @throws {@link UnauthorizedError} indicates an invalid authSessionId or no authSessionId was sent.
+ * @throws {@link ForbiddenError} indicates that a valid authSessionId for an external user was sent but external validation was set to false.
+ * @throws {@link NotFoundError} indicates that a valid token for a deleted user was sent.
  *
  * @example ```typescript
  * const user: ScimUser = await validateAuthSessionId("https://monster-ag.d-velop.cloud", "vXo4FMlnYYiGArNfjfJHEJDNWfjfejglgnewjgrjokgajifahfhdahfuewfhlR/4FxJxmNsjlq2XgWQm/GYVBq/hEvsJy1BK4WLoCXek=&ga8gds7gafkajgkj24ut8ugudash34jGlDG&dr6j0zusHVN8PcyerI0YXqRu30f8AGoUaZ6vInCDtZInS6aK2PplAelsv9t8");

--- a/packages/identityprovider/src/validate-auth-session-id/validate-auth-session-id.ts
+++ b/packages/identityprovider/src/validate-auth-session-id/validate-auth-session-id.ts
@@ -1,8 +1,16 @@
 import axios, { AxiosResponse } from "axios";
+import { followHalJson } from "@dvelop-sdk/axios-hal-json";
+import { ForbiddenError, NotFoundError, UnauthorizedError } from "../errors";
 import { ScimUser } from "./scim-user";
+axios.interceptors.request.use(followHalJson);
 
 /**
  * Validates an AuthSessionId and returns a [ScimUser]{@link ScimUser}
+ *
+ * @throws [[UnauthorizedError]] indicates that an invalid or no authSessionId was sent.
+ * @throws [[ForbiddenError]] indicates that a valid authSessionId for an external user was sent but external validation was set to false.
+ * @throws [[NotFoundError]] indicates that a valid token for a deleted user was sent.
+ *
  * @param {string} systemBaseUri SystemBaseUri for the tenant.
  * @param {string} authSessionId AuthSessionId which should be validated.
  * @returns {ScimUser}
@@ -13,12 +21,30 @@ import { ScimUser } from "./scim-user";
  * ```
  */
 export async function validateAuthSessionId(systemBaseUri: string, authSessionId: string): Promise<ScimUser> {
-  const response: AxiosResponse<ScimUser> = await axios.get<ScimUser>(`${systemBaseUri}/identityprovider/validate`, {
-    headers: {
-      "Authorization": `Bearer ${authSessionId}`
+
+  const errorContext: string = "Failed to validate authSessionId";
+
+  try {
+    const response: AxiosResponse<ScimUser> = await axios.get<ScimUser>("/identityprovider", {
+      baseURL: systemBaseUri,
+      headers: {
+        "Authorization": `Bearer ${authSessionId}`
+      },
+      follows: ["validate"]
+    });
+    return response.data;
+  } catch (e) {
+    if (e.response) {
+      switch (e.response.status) {
+      case 401:
+        throw new UnauthorizedError(errorContext, e.response);
+      case 403:
+        throw new ForbiddenError(errorContext, e.response);
+      case 404:
+        throw new NotFoundError(errorContext, e.response);
+      }
     }
-  }).catch(e => {
-    throw new Error(`Failed to validate AuthSessionId.\n${e}`);
-  });
-  return response.data;
+    e.message = `${errorContext}: ${e.message}`;
+    throw e;
+  }
 }

--- a/packages/task/package-lock.json
+++ b/packages/task/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@dvelop-sdk/task",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/task/package-lock.json
+++ b/packages/task/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@dvelop-sdk/task",
-    "version": "1.0.4",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dvelop-sdk/task",
   "description": "This package contains functionality for the Task-App in the d.velop cloud.",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dvelop-sdk/axios-hal-json": "^0.0.0",
+    "@dvelop-sdk/axios-hal-json": "^0.0.1",
     "axios": "^0.21.1",
     "uuid": "^8.3.2"
   },

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -20,6 +20,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@dvelop-sdk/axios-hal-json": "^0.0.0",
     "axios": "^0.21.1",
     "uuid": "^8.3.2"
   },

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dvelop-sdk/task",
   "description": "This package contains functionality for the Task-App in the d.velop cloud.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dvelop-sdk/axios-hal-json": "^1.0.0",
+    "@dvelop-sdk/axios-hal-json": "^1.0.1",
     "axios": "^0.21.1",
     "uuid": "^8.3.2"
   },

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dvelop-sdk/axios-hal-json": "^0.0.1",
+    "@dvelop-sdk/axios-hal-json": "^1.0.0",
     "axios": "^0.21.1",
     "uuid": "^8.3.2"
   },

--- a/packages/task/src/complete-task/complete-task.spec.ts
+++ b/packages/task/src/complete-task/complete-task.spec.ts
@@ -1,6 +1,6 @@
-import axios from "axios";
-import { Task } from "../task";
-import { completeTask } from "./complete-task";
+import axios, { AxiosResponse } from "axios";
+import { NoTaskLocationError, TaskNoFoundError, UnauthenticatedUserError, UnauthorizedUserError } from "../errors";
+import { completeTask, TaskAlreadyCompletedError } from "./complete-task";
 
 jest.mock("axios");
 
@@ -13,105 +13,192 @@ describe("completeTask", () => {
   });
 
   [
-    "", null, undefined
+    "HiItsMeLocation",
+    { location: "HiItsMeLocation" }
   ].forEach(testCase => {
 
-    it("should throw on missing location as string", async () => {
+    describe(`http-call with location ${typeof testCase === "string" ? "as string" : "in task"}`, () => {
 
-      const systemBaseUri = "HiItsMeSystemBaseUri";
-      const authessionId = "HiItsMeAuthsessionId";
+      beforeEach(() => {
+        mockedAxios.post.mockResolvedValue(null);
+      });
 
-      await expect(completeTask(systemBaseUri, authessionId, testCase)).rejects.toThrowError("Failed to complete Task.\nNo Location");
-    });
+      it("should do POST", async () => {
+        await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", testCase);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+      });
 
-    it("should throw on missing location in task", async () => {
+      it("should POST to location", async () => {
+        const location: string = typeof testCase === "string" ? testCase : testCase.location;
+        await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", testCase);
+        expect(mockedAxios.post).toHaveBeenCalledWith(`${location}/completionState`, expect.any(Object), expect.any(Object));
+      });
 
-      const systemBaseUri = "HiItsMeSystemBaseUri";
-      const authessionId = "HiItsMeAuthsessionId";
-      const task: Task = {
-        location: testCase,
-        subject: "Nice Subject",
-        description: "a description",
-      };
+      it("should POST with given task", async () => {
+        await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", testCase);
+        expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), { complete: true }, expect.any(Object));
+      });
 
-      await expect(completeTask(systemBaseUri, authessionId, task)).rejects.toThrowError("Failed to complete Task.\nNo Location");
-    });
-  });
+      it("should POST with systemBaseUri as BaseURL", async () => {
+        const systemBaseUri: string = "HiItsMeSystemBaseUri";
+        await completeTask(systemBaseUri, "HiItsMeAuthSessionId", testCase);
+        expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
+          baseURL: systemBaseUri
+        }));
+      });
 
-  it("should make POST with correct URI with location given", async () => {
+      it("should POST with authSessionId as Authorization-Header", async () => {
+        const authSessionId: string = "HiItsMeAuthSessionId";
+        await completeTask("HiItsMeSystemBaseUri", authSessionId, testCase);
+        expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
+          headers: expect.objectContaining({ "Authorization": `Bearer ${authSessionId}` })
+        }));
+      });
 
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-    const authessionId = "HiItsMeAuthsessionId";
-    const location = "/task/taks/1234567890";
-
-    await completeTask(systemBaseUri, authessionId, location);
-
-    expect(mockedAxios.post).toBeCalledWith(`${systemBaseUri}${location}/completionState`, expect.any(Object), expect.any(Object));
-  });
-
-  it("should make POST with correct URI with task object given", async () => {
-
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-    const authessionId = "HiItsMeAuthsessionId";
-    const myTask: Task = {
-      location: "/it/is/a/location/1234567890",
-      subject: "Nice Subject",
-      description: "a description",
-    };
-
-    await completeTask(systemBaseUri, authessionId, myTask);
-
-    expect(mockedAxios.post).toBeCalledWith(`${systemBaseUri}${myTask.location}/completionState`, expect.any(Object), expect.any(Object));
-  });
-
-  it("should make POST with correct headers", async () => {
-
-    const authessionId = "HiItsMeAuthsessionId";
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-    const location = "/task/taks/1234567890";
-
-    await completeTask(systemBaseUri, authessionId, location);
-
-    expect(mockedAxios.post).toBeCalledWith(expect.any(String), expect.any(Object), { headers: { "Authorization": `Bearer ${authessionId}`, "Origin": systemBaseUri } });
-  });
-
-  it("should make POST with correct body", async () => {
-
-    const authessionId = "HiItsMeAuthsessionId";
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-    const location = "/task/taks/1234567890";
-
-    const expectedBody = { "complete": true };
-
-
-    await completeTask(systemBaseUri, authessionId, location);
-
-    expect(mockedAxios.post).toBeCalledWith(expect.any(String), expectedBody, expect.any(Object));
-  });
-
-  [
-    { status: 401, error: "The user is not authenticated." },
-    { status: 403, error: "The user does not have the permission to complete this task." },
-    { status: 404, error: "The task does not exist." },
-    { status: 410, error: "This task was already completed." }
-  ].forEach(testCase => {
-    it(`should throw "${testCase.error}" on status ${testCase.status}`, async () => {
-      mockedAxios.post.mockRejectedValue({ response: { status: testCase.status } });
-      await expect(completeTask("HiItsMeAuthsessionId", "HiItsMeAuthsessionId", "/task/taks/1234567890")).rejects.toThrowError(testCase.error);
+      it("should POST with systemBaseUri as Origin-Header", async () => {
+        const systemBaseUri: string = "HiItsMeSystemBaseUri";
+        await completeTask(systemBaseUri, "HiItsMeAuthSessionId", testCase);
+        expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
+          headers: expect.objectContaining({ "Origin": systemBaseUri })
+        }));
+      });
     });
   });
 
-  [100, 300, 414, 503].forEach(testCase => {
-    it("should throw generic error on unknown status", async () => {
-      const response = { response: { status: testCase, message: "HiItsMeError" } };
-      mockedAxios.post.mockRejectedValue(response);
 
-      await expect(completeTask("HiItsMeAuthsessionId", "HiItsMeAuthsessionId", "/task/taks/1234567890")).rejects.toThrowError(`Failed to create Task: ${JSON.stringify(response)}`);
+  describe("errors", () => {
+
+    [
+      "",
+      null,
+      undefined
+    ].forEach(testCaseLocation => {
+      [
+        testCaseLocation,
+        { location: testCaseLocation }
+      ].forEach(testCaseTask => {
+        it(`should throw NoTaskLocationError on location=${testCaseLocation} ${typeof testCaseTask === "string" ? "as string" : "in task"}`, async () => {
+
+          let error: NoTaskLocationError;
+          try {
+            await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", testCaseTask);
+          } catch (e) {
+            error = e;
+          }
+
+          expect(error instanceof NoTaskLocationError).toBeTruthy();
+          expect(error.message).toContain("Failed to complete task");
+          expect(error.task).toEqual(testCaseTask);
+          expect(mockedAxios.post).toHaveBeenCalledTimes(0);
+        });
+      });
     });
-  });
 
-  it("should throw generic error on unknown error", async () => {
-    mockedAxios.post.mockRejectedValue({});
-    await expect(completeTask("HiItsMeAuthsessionId", "HiItsMeAuthsessionId", "/task/taks/1234567890")).rejects.toThrowError(`Failed to create Task: ${JSON.stringify({})}`);
+    it("should throw UnauthenticatedUserError on status 401", async () => {
+
+      const response: AxiosResponse = {
+        status: 401
+      } as AxiosResponse;
+
+      mockedAxios.post.mockRejectedValue({ response });
+
+      let error: UnauthenticatedUserError;
+      try {
+        await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", "HiItsMeLocation");
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error instanceof UnauthenticatedUserError).toBeTruthy();
+      expect(error.message).toContain("Failed to complete task:");
+      expect(error.response).toEqual(response);
+    });
+
+
+    it("should throw UnauthorizedUserError on status 403", async () => {
+
+      const response: AxiosResponse = {
+        status: 403,
+      } as AxiosResponse;
+
+      mockedAxios.post.mockRejectedValue({ response });
+
+      let error: UnauthorizedUserError;
+      try {
+        await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", "HiItsMeLocation");
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error instanceof UnauthorizedUserError).toBeTruthy();
+      expect(error.message).toContain("Failed to complete task:");
+      expect(error.response).toEqual(response);
+    });
+
+    it("should throw UnauthorizedUserError on status 404", async () => {
+
+      const location = "HiItsMeLocation";
+
+      const response: AxiosResponse = {
+        status: 404,
+      } as AxiosResponse;
+
+      mockedAxios.post.mockRejectedValue({ response });
+
+      let error: TaskNoFoundError;
+      try {
+        await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", location);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error instanceof TaskNoFoundError).toBeTruthy();
+      expect(error.message).toContain("Failed to complete task:");
+      expect(error.location).toEqual(location);
+      expect(error.response).toEqual(response);
+    });
+
+    it("should throw TaskAlreadyCompletedError on status 410", async () => {
+
+      const location = "HiItsMeLocation";
+
+      const response: AxiosResponse = {
+        status: 410,
+      } as AxiosResponse;
+
+      mockedAxios.post.mockRejectedValue({ response });
+
+      let error: TaskAlreadyCompletedError;
+      try {
+        await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", location);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error instanceof TaskAlreadyCompletedError).toBeTruthy();
+      expect(error.message).toContain("Failed to complete task:");
+      expect(error.location).toEqual(location);
+      expect(error.response).toEqual(response);
+    });
+
+    it("should rethrow with added context on unknown error", async () => {
+
+      const errorString: string = "HiItsMeError";
+      const error: Error = new Error(errorString);
+      mockedAxios.post.mockImplementation(() => {
+        throw error;
+      });
+
+      let resultError: Error;
+      try {
+        await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", "HiItsMeLocation");
+      } catch (e) {
+        resultError = e;
+      }
+
+      expect(resultError).toBe(error);
+      expect(resultError.message).toContain(errorString);
+      expect(resultError.message).toContain("Failed to complete task:");
+    });
   });
 });

--- a/packages/task/src/complete-task/complete-task.spec.ts
+++ b/packages/task/src/complete-task/complete-task.spec.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from "axios";
-import { NoTaskLocationError, TaskNoFoundError, UnauthenticatedUserError, UnauthorizedUserError } from "../errors";
+import { NoTaskLocationError, TaskNotFoundError, UnauthenticatedError, UnauthorizedError } from "../errors";
 import { completeTask, TaskAlreadyCompletedError } from "./complete-task";
 
 jest.mock("axios");
@@ -94,7 +94,7 @@ describe("completeTask", () => {
       });
     });
 
-    it("should throw UnauthenticatedUserError on status 401", async () => {
+    it("should throw UnauthenticatedError on status 401", async () => {
 
       const response: AxiosResponse = {
         status: 401
@@ -102,20 +102,20 @@ describe("completeTask", () => {
 
       mockedAxios.post.mockRejectedValue({ response });
 
-      let error: UnauthenticatedUserError;
+      let error: UnauthenticatedError;
       try {
         await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", "HiItsMeLocation");
       } catch (e) {
         error = e;
       }
 
-      expect(error instanceof UnauthenticatedUserError).toBeTruthy();
+      expect(error instanceof UnauthenticatedError).toBeTruthy();
       expect(error.message).toContain("Failed to complete task:");
       expect(error.response).toEqual(response);
     });
 
 
-    it("should throw UnauthorizedUserError on status 403", async () => {
+    it("should throw UnauthorizedError on status 403", async () => {
 
       const response: AxiosResponse = {
         status: 403,
@@ -123,19 +123,19 @@ describe("completeTask", () => {
 
       mockedAxios.post.mockRejectedValue({ response });
 
-      let error: UnauthorizedUserError;
+      let error: UnauthorizedError;
       try {
         await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", "HiItsMeLocation");
       } catch (e) {
         error = e;
       }
 
-      expect(error instanceof UnauthorizedUserError).toBeTruthy();
+      expect(error instanceof UnauthorizedError).toBeTruthy();
       expect(error.message).toContain("Failed to complete task:");
       expect(error.response).toEqual(response);
     });
 
-    it("should throw UnauthorizedUserError on status 404", async () => {
+    it("should throw TaskNotFoundError on status 404", async () => {
 
       const location = "HiItsMeLocation";
 
@@ -145,15 +145,16 @@ describe("completeTask", () => {
 
       mockedAxios.post.mockRejectedValue({ response });
 
-      let error: TaskNoFoundError;
+      let error: TaskNotFoundError;
       try {
         await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", location);
       } catch (e) {
         error = e;
       }
 
-      expect(error instanceof TaskNoFoundError).toBeTruthy();
+      expect(error instanceof TaskNotFoundError).toBeTruthy();
       expect(error.message).toContain("Failed to complete task:");
+      expect(error.message).toContain(location);
       expect(error.location).toEqual(location);
       expect(error.response).toEqual(response);
     });

--- a/packages/task/src/complete-task/complete-task.spec.ts
+++ b/packages/task/src/complete-task/complete-task.spec.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from "axios";
-import { NoTaskLocationError, TaskNotFoundError, UnauthenticatedError, UnauthorizedError } from "../errors";
-import { completeTask, TaskAlreadyCompletedError } from "./complete-task";
+import { NoTaskLocationError, TaskNotFoundError, UnauthenticatedError, UnauthorizedError, TaskAlreadyCompletedError } from "../errors";
+import { completeTask } from "./complete-task";
 
 jest.mock("axios");
 

--- a/packages/task/src/complete-task/complete-task.spec.ts
+++ b/packages/task/src/complete-task/complete-task.spec.ts
@@ -34,7 +34,7 @@ describe("completeTask", () => {
         expect(mockedAxios.post).toHaveBeenCalledWith(`${location}/completionState`, expect.any(Object), expect.any(Object));
       });
 
-      it("should POST with given task", async () => {
+      it("should POST with given { complete: true }", async () => {
         await completeTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", testCase);
         expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), { complete: true }, expect.any(Object));
       });

--- a/packages/task/src/complete-task/complete-task.ts
+++ b/packages/task/src/complete-task/complete-task.ts
@@ -20,7 +20,7 @@ export class TaskAlreadyCompletedError extends Error {
  * @throws [[NoTaskLocationError]] indicates that no location was given.
  * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
  * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
- * @throws [[TaskNotFoundError]] indicates that for the given task does not exist.
+ * @throws [[TaskNotFoundError]] indicates that for the given location no task was found.
  * @throws [[TaskAlreadyCompleted]] indicates that a task is already marked as completed.
  *
  * @param {string} systemBaseUri SystemBaseUri for the tenant

--- a/packages/task/src/complete-task/complete-task.ts
+++ b/packages/task/src/complete-task/complete-task.ts
@@ -4,21 +4,21 @@ import { Task } from "../task";
 
 
 /**
- * Marks a [Task]{@link Task} as completed.
- *
- * @throws [[NoTaskLocationError]] indicates that no location was given.
- * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
- * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
- * @throws [[TaskNotFoundError]] indicates that for the given location no task was found.
- * @throws [[TaskAlreadyCompleted]] indicates that a task is already marked as completed.
+ * Mark a {@link Task} as completed.
  *
  * @param {string} systemBaseUri SystemBaseUri for the tenant
  * @param {string} authSessionId Vaild AuthSessionId
- * @param {string|Task} task Location of a task or the [Task]{@link Task} itself
+ * @param {string|Task} task Location of the task or {@link Task}
  *
+ * @throws {@link NoTaskLocationError} indicates that no location was given.
+ * @throws {@link UnauthenticatedError} indicates that the authSessionId was invalid or expired.
+ * @throws {@link UnauthorizedError} indicates that the user associated with the authSessionId does miss permissions.
+ * @throws {@link TaskNotFoundError} indicates that for the given location no task was found.
+ * @throws {@link TaskAlreadyCompletedError} indicates that a task is already marked as completed.
+
  * @example ```typescript
- * const taskLocation: string = "/some/task/location";
- * await completeTask("https://umbrella-corp.d-velop.cloud", "AUTH_SESSION_ID", taskLocation);
+ *
+ * await completeTask("https://umbrella-corp.d-velop.cloud", "AUTH_SESSION_ID", "/some/task/location");
  *
  * // or
  *
@@ -28,7 +28,7 @@ import { Task } from "../task";
  * }
  * await completeTask("https://umbrella-corp.d-velop.cloud", "AUTH_SESSION_ID", task);
  * ```
- */
+  */
 
 export async function completeTask(systemBaseUri: string, authSessionId: string, task: string | Task): Promise<void> {
 

--- a/packages/task/src/complete-task/complete-task.ts
+++ b/packages/task/src/complete-task/complete-task.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from "axios";
-import { NoTaskLocationError, TaskNoFoundError, UnauthenticatedUserError, UnauthorizedUserError } from "../errors";
+import { NoTaskLocationError, TaskNotFoundError, UnauthenticatedError, UnauthorizedError } from "../errors";
 import { Task } from "../task";
 
 /**
@@ -16,6 +16,12 @@ export class TaskAlreadyCompletedError extends Error {
 
 /**
  * Marks a [Task]{@link Task} as completed.
+ *
+ * @throws [[NoTaskLocationError]] indicates that no location was given.
+ * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
+ * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
+ * @throws [[TaskNotFoundError]] indicates that for the given task does not exist.
+ * @throws [[TaskAlreadyCompleted]] indicates that a task is already marked as completed.
  *
  * @param {string} systemBaseUri SystemBaseUri for the tenant
  * @param {string} authSessionId Vaild AuthSessionId
@@ -60,11 +66,11 @@ export async function completeTask(systemBaseUri: string, authSessionId: string,
     if (e.response) {
       switch (e.response.status) {
       case 401:
-        throw new UnauthenticatedUserError(context, e.response);
+        throw new UnauthenticatedError(context, e.response);
       case 403:
-        throw new UnauthorizedUserError(context, e.response);
+        throw new UnauthorizedError(context, e.response);
       case 404:
-        throw new TaskNoFoundError(context, location, e.response);
+        throw new TaskNotFoundError(context, location, e.response);
       case 410:
         throw new TaskAlreadyCompletedError(context, location, e.response);
       }

--- a/packages/task/src/create-task/create-task.spec.ts
+++ b/packages/task/src/create-task/create-task.spec.ts
@@ -2,7 +2,7 @@ import axios, { AxiosResponse } from "axios";
 import "@dvelop-sdk/axios-hal-json";
 import { createTask, InvalidTaskError } from "./create-task";
 import { Task } from "../task";
-import { UnauthenticatedUserError, UnauthorizedUserError } from "../errors";
+import { UnauthenticatedError, UnauthorizedError } from "../errors";
 
 jest.mock("axios");
 
@@ -151,7 +151,7 @@ describe("createTask", () => {
       expect(error.response).toEqual(response);
     });
 
-    it("should throw UnauthenticatedUserError on status 401", async () => {
+    it("should throw UnauthenticatedError on status 401", async () => {
 
       const response: AxiosResponse = {
         data: {},
@@ -160,19 +160,19 @@ describe("createTask", () => {
 
       mockedAxios.post.mockRejectedValue({ response });
 
-      let error: UnauthenticatedUserError;
+      let error: UnauthenticatedError;
       try {
         await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
       } catch (e) {
         error = e;
       }
 
-      expect(error instanceof UnauthenticatedUserError).toBeTruthy();
+      expect(error instanceof UnauthenticatedError).toBeTruthy();
       expect(error.message).toContain("Failed to create Task:");
       expect(error.response).toEqual(response);
     });
 
-    it("should throw UnauthorizedUserError on status 403", async () => {
+    it("should throw UnauthorizedError on status 403", async () => {
 
       const response: AxiosResponse = {
         data: {},
@@ -181,14 +181,14 @@ describe("createTask", () => {
 
       mockedAxios.post.mockRejectedValue({ response });
 
-      let error: UnauthorizedUserError;
+      let error: UnauthorizedError;
       try {
         await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
       } catch (e) {
         error = e;
       }
 
-      expect(error instanceof UnauthorizedUserError).toBeTruthy();
+      expect(error instanceof UnauthorizedError).toBeTruthy();
       expect(error.message).toContain("Failed to create Task:");
       expect(error.response).toEqual(response);
     });

--- a/packages/task/src/create-task/create-task.spec.ts
+++ b/packages/task/src/create-task/create-task.spec.ts
@@ -1,8 +1,8 @@
 import axios, { AxiosResponse } from "axios";
 import "@dvelop-sdk/axios-hal-json";
-import { createTask, InvalidTaskError } from "./create-task";
+import { createTask } from "./create-task";
 import { Task } from "../task";
-import { UnauthenticatedError, UnauthorizedError } from "../errors";
+import { InvalidTaskError, UnauthenticatedError, UnauthorizedError } from "../errors";
 
 jest.mock("axios");
 
@@ -145,7 +145,7 @@ describe("createTask", () => {
       }
 
       expect(error instanceof InvalidTaskError).toBeTruthy();
-      expect(error.message).toContain("Failed to create Task:");
+      expect(error.message).toContain("Failed to create task:");
       expect(error.task).toEqual(expect.objectContaining(task));
       expect(error.validation).toEqual(data);
       expect(error.response).toEqual(response);
@@ -168,7 +168,7 @@ describe("createTask", () => {
       }
 
       expect(error instanceof UnauthenticatedError).toBeTruthy();
-      expect(error.message).toContain("Failed to create Task:");
+      expect(error.message).toContain("Failed to create task:");
       expect(error.response).toEqual(response);
     });
 
@@ -189,7 +189,7 @@ describe("createTask", () => {
       }
 
       expect(error instanceof UnauthorizedError).toBeTruthy();
-      expect(error.message).toContain("Failed to create Task:");
+      expect(error.message).toContain("Failed to create task:");
       expect(error.response).toEqual(response);
     });
 
@@ -211,7 +211,7 @@ describe("createTask", () => {
 
       expect(resultError).toBe(error);
       expect(resultError.message).toContain(errorString);
-      expect(resultError.message).toContain("Failed to create Task:");
+      expect(resultError.message).toContain("Failed to create task:");
     });
   });
 });

--- a/packages/task/src/create-task/create-task.spec.ts
+++ b/packages/task/src/create-task/create-task.spec.ts
@@ -1,6 +1,8 @@
-import axios from "axios";
-import { createTask } from "./create-task";
+import axios, { AxiosResponse } from "axios";
+import "@dvelop-sdk/axios-hal-json";
+import { createTask, InvalidTaskError } from "./create-task";
 import { Task } from "../task";
+import { UnauthenticatedUserError, UnauthorizedUserError } from "../errors";
 
 jest.mock("axios");
 
@@ -10,143 +12,206 @@ describe("createTask", () => {
 
   beforeEach(() => {
     mockedAxios.post.mockReset();
-    mockedAxios.post.mockResolvedValue({
-      headers: {
-        location: "some/location/uri/4711"
+  });
+
+  describe("axios-params", () => {
+
+    beforeEach(() => {
+      mockedAxios.post.mockResolvedValue({
+        headers: { location: "HiItsMeLocations" }
+      });
+    });
+
+    it("should do POST", async () => {
+      await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    });
+
+    it("should POST to /task", async () => {
+      await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
+      expect(mockedAxios.post).toHaveBeenCalledWith("/task", expect.any(Object), expect.any(Object));
+    });
+
+    it("should POST with given task", async () => {
+      const task: Task = { subject: "HiItsMeSubject", correlationKey: "HiItsMeCorrelationKey" };
+      await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", { ...task });
+      expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.objectContaining(task), expect.any(Object));
+    });
+
+    it("should POST given task with added correlationKey if none given", async () => {
+      const task: Task = { subject: "HiItsMeSubject" };
+      await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", { ...task });
+      expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.objectContaining(task), expect.any(Object));
+      expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ correlationKey: expect.any(String) }), expect.any(Object));
+    });
+
+    it("should POST with systemBaseUri as BaseURL", async () => {
+      const systemBaseUri: string = "HiItsMeSystemBaseUri";
+      await createTask(systemBaseUri, "HiItsMeAuthSessionId", {});
+      expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
+        baseURL: systemBaseUri
+      }));
+    });
+
+    it("should POST with authSessionId as Authorization-Header", async () => {
+      const authSessionId: string = "HiItsMeAuthSessionId";
+      await createTask("HiItsMeSystemBaseUri", authSessionId, {});
+      expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
+        headers: expect.objectContaining({ "Authorization": `Bearer ${authSessionId}` })
+      }));
+    });
+
+    it("should POST with systemBaseUri as Origin-Header", async () => {
+      const systemBaseUri: string = "HiItsMeSystemBaseUri";
+      await createTask(systemBaseUri, "HiItsMeAuthSessionId", {});
+      expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
+        headers: expect.objectContaining({ "Origin": systemBaseUri })
+      }));
+    });
+
+    it("should POST with follows: tasks", async () => {
+      await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
+      expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
+        follows: ["tasks"]
+      }));
+    });
+  });
+
+  describe("response", () => {
+
+    it("should return task", async () => {
+
+      const task: Task = {
+        subject: "HiItsMeSubject",
+        context: { name: "HiItsMeContext" }
+      };
+
+      mockedAxios.post.mockResolvedValue({
+        headers: { location: "HiItsMeLocations" }
+      });
+
+      const result: Task = await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", task);
+      expect(result).toEqual(expect.objectContaining(task));
+    });
+
+    it("should set location from header", async () => {
+
+      const location: string = "HiItsMeLocation";
+
+      mockedAxios.post.mockResolvedValue({
+        headers: { location: location }
+      });
+
+      const result: Task = await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
+      expect(result).toEqual(expect.objectContaining({ location: location }));
+    });
+
+    it("should set correlationKey", async () => {
+
+      const location: string = "HiItsMeLocation";
+
+      mockedAxios.post.mockResolvedValue({
+        headers: { location: location }
+      });
+
+      const result: Task = await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
+      expect(result).toEqual(expect.objectContaining({ correlationKey: expect.any(String) }));
+    });
+  });
+
+  describe("errors", () => {
+
+    it("should throw InvalidTaskError on status 400", async () => {
+
+      const task: Task = {
+        subject: "HiItsMeSubject",
+        context: { name: "HiItsMeContext" }
+      };
+
+      const data: any = { hiitsme: "ValidationJson" };
+
+      const response: AxiosResponse = {
+        data,
+        status: 400,
+      } as AxiosResponse;
+
+      mockedAxios.post.mockRejectedValue({ response });
+
+      let error: InvalidTaskError;
+      try {
+        await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", task);
+      } catch (e) {
+        error = e;
       }
+
+      expect(error instanceof InvalidTaskError).toBeTruthy();
+      expect(error.message).toContain("Failed to create Task:");
+      expect(error.task).toEqual(expect.objectContaining(task));
+      expect(error.validation).toEqual(data);
+      expect(error.response).toEqual(response);
     });
-  });
 
-  it("should make POST with correct URI", async () => {
+    it("should throw UnauthenticatedUserError on status 401", async () => {
 
-    const authessionId = "HiItsMeAuthsessionId";
-    const systemBaseUri = "HiItsMeSystemBaseUri";
+      const response: AxiosResponse = {
+        data: {},
+        status: 401,
+      } as AxiosResponse;
 
-    let task: Task = {
-      subject: "Some nice subject for your work",
-      assignees: ["HereShouldStandAndUserOrGroupId"],
-      correlationKey: "IAmSoUnique",
-    };
+      mockedAxios.post.mockRejectedValue({ response });
 
-    await createTask(systemBaseUri, authessionId, task);
-
-    expect(mockedAxios.post).toBeCalledWith(`${systemBaseUri}/task/tasks`, expect.any(Object), expect.any(Object));
-  });
-
-  it("should make POST with correct headers", async () => {
-
-    const authessionId = "HiItsMeAuthsessionId";
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-
-    let task: Task = {
-      subject: "Some nice subject for your work",
-      assignees: ["HereShouldStandAndUserOrGroupId"],
-      correlationKey: "IAmSoUnique",
-    };
-
-    await createTask(systemBaseUri, authessionId, task);
-
-    expect(mockedAxios.post).toBeCalledWith(expect.any(String), expect.any(Object), { headers: { "Authorization": `Bearer ${authessionId}`, "Origin": systemBaseUri } });
-  });
-
-  it("should make POST with correct body", async () => {
-
-    const authessionId = "HiItsMeAuthsessionId";
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-
-    let task: Task = {
-      subject: "Some nice subject for your work",
-      assignees: ["HereShouldStandAndUserOrGroupId"],
-      correlationKey: "IAmSoUnique",
-    };
-
-    await createTask(systemBaseUri, authessionId, task);
-
-    expect(mockedAxios.post).toBeCalledWith(expect.any(String), task, expect.any(Object));
-  });
-
-  it("should generate a correlation key", async () => {
-
-    const authessionId = "HiItsMeAuthsessionId";
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-
-    let task: Task = {
-      subject: "Some nice subject for your work",
-      assignees: ["HereShouldStandAndUserOrGroupId"]
-    };
-
-    const createdTask: Task = await createTask(systemBaseUri, authessionId, task);
-
-    expect(createdTask.correlationKey).not.toBeUndefined();
-    expect(createdTask.correlationKey).not.toBeNull();
-    expect(createdTask.correlationKey).not.toEqual("");
-  });
-
-  it("should use the correlation key the user added to the task object", async () => {
-
-    const authessionId = "HiItsMeAuthsessionId";
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-
-    let task: Task = {
-      subject: "Some nice subject for your work",
-      assignees: ["HereShouldStandAndUserOrGroupId"],
-      correlationKey: "IAmSoUnique",
-    };
-
-    const createdTask: Task = await createTask(systemBaseUri, authessionId, task);
-
-    expect(createdTask.correlationKey).toEqual("IAmSoUnique");
-  });
-
-  it("should return the correct location", async () => {
-
-    const authessionId = "HiItsMeAuthsessionId";
-    const systemBaseUri = "HiItsMeSystemBaseUri";
-
-    let task: Task = {
-      subject: "Some nice subject for your work",
-      assignees: ["HereShouldStandAndUserOrGroupId"],
-      correlationKey: "IAmSoUnique",
-    };
-
-    mockedAxios.post.mockResolvedValue({
-      headers: {
-        location: "some/location/uri/abcdefg"
+      let error: UnauthenticatedUserError;
+      try {
+        await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
+      } catch (e) {
+        error = e;
       }
+
+      expect(error instanceof UnauthenticatedUserError).toBeTruthy();
+      expect(error.message).toContain("Failed to create Task:");
+      expect(error.response).toEqual(response);
     });
 
-    const createdTask: Task = await createTask(systemBaseUri, authessionId, task);
+    it("should throw UnauthorizedUserError on status 403", async () => {
 
-    expect(createdTask.location).toEqual("some/location/uri/abcdefg");
-  });
+      const response: AxiosResponse = {
+        data: {},
+        status: 403,
+      } as AxiosResponse;
 
-  it("should throw error containing validation JSON", async () => {
-    const validationJson = { someValue: false };
-    mockedAxios.post.mockRejectedValue({ response: { status: 400, data: validationJson } });
-    await expect(createTask("HiItsMeAuthsessionId", "HiItsMeAuthsessionId", {})).rejects.toThrowError(`Task is invalid.\nValidation: ${JSON.stringify(validationJson)}`);
-  });
+      mockedAxios.post.mockRejectedValue({ response });
 
-  [
-    { status: 401, error: "The user is not authenticated." },
-    { status: 403, error: "The user is not eligible to create the task." },
-  ].forEach(testCase => {
-    it(`should throw "${testCase.error}" on status ${testCase.status}`, async () => {
-      mockedAxios.post.mockRejectedValue({ response: { status: testCase.status } });
-      await expect(createTask("HiItsMeAuthsessionId", "HiItsMeAuthsessionId", {})).rejects.toThrowError(testCase.error);
+      let error: UnauthorizedUserError;
+      try {
+        await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error instanceof UnauthorizedUserError).toBeTruthy();
+      expect(error.message).toContain("Failed to create Task:");
+      expect(error.response).toEqual(response);
     });
-  });
 
-  [100, 300, 414, 503].forEach(testCase => {
-    it("should throw generic error on unknown status", async () => {
-      const response = { response: { status: testCase, message: "HiItsMeError" } };
-      mockedAxios.post.mockRejectedValue(response);
 
-      await expect(createTask("HiItsMeAuthsessionId", "HiItsMeAuthsessionId", {})).rejects.toThrowError(`Failed to create Task: ${JSON.stringify(response)}`);
+    it("should throw UnknownErrors", async () => {
+
+      const errorString: string = "HiItsMeError";
+      const error: Error = new Error(errorString);
+      mockedAxios.post.mockImplementation(() => {
+        throw error;
+      });
+
+      let resultError: Error;
+      try {
+        await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
+      } catch (e) {
+        resultError = e;
+      }
+
+      expect(resultError).toBe(error);
+      expect(resultError.message).toContain(errorString);
+      expect(resultError.message).toContain("Failed to create Task:");
     });
-  });
-
-  it("should throw generic error on unknown error", async () => {
-    mockedAxios.post.mockRejectedValue({});
-    await expect(createTask("HiItsMeAuthsessionId", "HiItsMeAuthsessionId", {})).rejects.toThrowError(`Failed to create Task: ${JSON.stringify({})}`);
   });
 });

--- a/packages/task/src/create-task/create-task.spec.ts
+++ b/packages/task/src/create-task/create-task.spec.ts
@@ -22,30 +22,30 @@ describe("createTask", () => {
       });
     });
 
-    it("should do POST", async () => {
+    it("should send POST", async () => {
       await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
       expect(mockedAxios.post).toHaveBeenCalledTimes(1);
     });
 
-    it("should POST to /task", async () => {
+    it("should send to /task", async () => {
       await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
       expect(mockedAxios.post).toHaveBeenCalledWith("/task", expect.any(Object), expect.any(Object));
     });
 
-    it("should POST with given task", async () => {
+    it("should send with given task", async () => {
       const task: Task = { subject: "HiItsMeSubject", correlationKey: "HiItsMeCorrelationKey" };
       await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", { ...task });
       expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.objectContaining(task), expect.any(Object));
     });
 
-    it("should POST given task with added correlationKey if none given", async () => {
+    it("should send given task with added correlationKey if none given", async () => {
       const task: Task = { subject: "HiItsMeSubject" };
       await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", { ...task });
       expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.objectContaining(task), expect.any(Object));
       expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ correlationKey: expect.any(String) }), expect.any(Object));
     });
 
-    it("should POST with systemBaseUri as BaseURL", async () => {
+    it("should send with systemBaseUri as BaseURL", async () => {
       const systemBaseUri: string = "HiItsMeSystemBaseUri";
       await createTask(systemBaseUri, "HiItsMeAuthSessionId", {});
       expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
@@ -53,7 +53,7 @@ describe("createTask", () => {
       }));
     });
 
-    it("should POST with authSessionId as Authorization-Header", async () => {
+    it("should send with authSessionId as Authorization-Header", async () => {
       const authSessionId: string = "HiItsMeAuthSessionId";
       await createTask("HiItsMeSystemBaseUri", authSessionId, {});
       expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
@@ -61,7 +61,7 @@ describe("createTask", () => {
       }));
     });
 
-    it("should POST with systemBaseUri as Origin-Header", async () => {
+    it("should send with systemBaseUri as Origin-Header", async () => {
       const systemBaseUri: string = "HiItsMeSystemBaseUri";
       await createTask(systemBaseUri, "HiItsMeAuthSessionId", {});
       expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
@@ -69,7 +69,7 @@ describe("createTask", () => {
       }));
     });
 
-    it("should POST with follows: tasks", async () => {
+    it("should send with follows: tasks", async () => {
       await createTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", {});
       expect(mockedAxios.post).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.objectContaining({
         follows: ["tasks"]

--- a/packages/task/src/create-task/create-task.ts
+++ b/packages/task/src/create-task/create-task.ts
@@ -2,7 +2,7 @@ import axios, { AxiosResponse } from "axios";
 import { followHalJson } from "@dvelop-sdk/axios-hal-json";
 import { Task } from "../task";
 import { v4 } from "uuid";
-import { UnauthenticatedUserError, UnauthorizedUserError } from "../errors";
+import { UnauthenticatedError, UnauthorizedError } from "../errors";
 axios.interceptors.request.use(followHalJson);
 
 /**
@@ -19,6 +19,10 @@ export class InvalidTaskError extends Error {
 
 /**
  * Creates a [Task]{@link Task} and returns it. This method will automatically generate a random correlation key if the task does not contain one.
+ *
+ * @throws [[InvalidTaskError]] indicates that the given task was not accepted because it is invalid. You can check the ```error.validation```-property.
+ * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
+ * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
  *
  * @param {string} systemBaseUri SystemBaseUri for the tenant
  * @param {string} authRessionId Vaild AuthSessionId
@@ -60,9 +64,9 @@ export async function createTask(systemBaseUri: string, authSessionId: string, t
       case 400:
         throw new InvalidTaskError(task, e.response.data, e.response);
       case 401:
-        throw new UnauthenticatedUserError("Failed to create Task", e.response);
+        throw new UnauthenticatedError("Failed to create Task", e.response);
       case 403:
-        throw new UnauthorizedUserError("Failed to create Task", e.response);
+        throw new UnauthorizedError("Failed to create Task", e.response);
       }
     }
     e.message = "Failed to create Task: " + e.message;

--- a/packages/task/src/create-task/create-task.ts
+++ b/packages/task/src/create-task/create-task.ts
@@ -7,24 +7,27 @@ axios.interceptors.request.use(followHalJson);
 
 
 /**
- * Creates a [Task]{@link Task} and returns it. This method will automatically generate a random correlation key if the task does not contain one.
+ * Create a {@link Task}.
  *
- * @throws [[InvalidTaskError]] indicates that the given task was not accepted because it is invalid. You can check the ```error.validation```-property.
- * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
- * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
+ * *This method will automatically generate a random correlation key if the task does not contain one.*
  *
  * @param {string} systemBaseUri SystemBaseUri for the tenant
- * @param {string} authRessionId Vaild AuthSessionId
- * @param {Task} task Task to be created
- * @returns {Task} Created Task
+ * @param {string} authRessionId Valid AuthSessionId
+ * @param {Task} task {@link Task} to be created
+ * @returns {Task} Created {@link Task}
+ *
+ * @throws {@link InvalidTaskError} indicates that the given task was not accepted because it is invalid. You can check the ```error.validation```-property.
+ * @throws {@link UnauthenticatedError} indicates that the authSessionId was invalid or expired.
+ * @throws {@link UnauthorizedError} indicates that the user associated with the authSessionId does miss permissions.
  *
  * @example ```typescript
+ *
  * const task: Task = {
  *   subject: "Cover up lab accident",
  *   assignees: ["USER_ID_1", "USER_ID_2"],
  *   correlationKey: "everythingIsFine", // can be randomly generated
  * }
- * task = await createTask("https://umbrella-corp.d-velop.cloud", "AUTH_SESSION_ID ", task);
+ * task = await createTask("https://umbrella-corp.d-velop.cloud", "AUTH_SESSION_ID", task);
  * ```
  */
 export async function createTask(systemBaseUri: string, authSessionId: string, task: Task): Promise<Task> {

--- a/packages/task/src/delete-task/delete-task.spec.ts
+++ b/packages/task/src/delete-task/delete-task.spec.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from "axios";
-import { NoTaskLocationError, TaskNotFoundError, UnauthenticatedError, UnauthorizedError } from "../errors";
+import { NoTaskLocationError, TaskAlreadyCompletedError, TaskNotFoundError, UnauthenticatedError, UnauthorizedError } from "../errors";
 import { deleteTask } from "./delete-task";
 
 jest.mock("axios");
@@ -150,6 +150,29 @@ describe("deleteTask", () => {
       expect(error instanceof TaskNotFoundError).toBeTruthy();
       expect(error.message).toContain("Failed to delete task:");
       expect(error.message).toContain(location);
+      expect(error.location).toEqual(location);
+      expect(error.response).toEqual(response);
+    });
+
+    it("should throw TaskAlreadyCompletedError on status 410", async () => {
+
+      const location = "HiItsMeLocation";
+
+      const response: AxiosResponse = {
+        status: 410,
+      } as AxiosResponse;
+
+      mockedAxios.delete.mockRejectedValue({ response });
+
+      let error: TaskAlreadyCompletedError;
+      try {
+        await deleteTask("HiItsMeSystemBaseUri", "HiItsMeAuthSessionId", location);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error instanceof TaskAlreadyCompletedError).toBeTruthy();
+      expect(error.message).toContain("Failed to delete task:");
       expect(error.location).toEqual(location);
       expect(error.response).toEqual(response);
     });

--- a/packages/task/src/delete-task/delete-task.ts
+++ b/packages/task/src/delete-task/delete-task.ts
@@ -32,7 +32,7 @@ import { Task } from "../task";
 
 export async function deleteTask(systemBaseUri: string, authSessionId: string, task: string | Task): Promise<void> {
 
-  const context: string = "Failed to delete task";
+  const errorContext: string = "Failed to delete task";
   let location: string;
 
   if (task && typeof task === "string") {
@@ -40,7 +40,7 @@ export async function deleteTask(systemBaseUri: string, authSessionId: string, t
   } else if (task && (task as Task).location) {
     location = (task as Task).location!;
   } else {
-    throw new NoTaskLocationError(context, task);
+    throw new NoTaskLocationError(errorContext, task);
   }
 
   try {
@@ -55,14 +55,14 @@ export async function deleteTask(systemBaseUri: string, authSessionId: string, t
     if (e.response) {
       switch (e.response.status) {
       case 401:
-        throw new UnauthenticatedError(context, e.response);
+        throw new UnauthenticatedError(errorContext, e.response);
       case 403:
-        throw new UnauthorizedError(context, e.response);
+        throw new UnauthorizedError(errorContext, e.response);
       case 404:
-        throw new TaskNotFoundError(context, location, e.response);
+        throw new TaskNotFoundError(errorContext, location, e.response);
       }
     }
-    e.message = `${context}: ${e.message}`;
+    e.message = `${errorContext}: ${e.message}`;
     throw e;
   }
 }

--- a/packages/task/src/delete-task/delete-task.ts
+++ b/packages/task/src/delete-task/delete-task.ts
@@ -10,6 +10,7 @@ import { Task } from "../task";
  * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
  * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
  * @throws [[TaskNotFoundError]] indicates that for the given location no task was found.
+ * @throws [[TaskAlreadyCompleted]] indicates that a task is already marked as completed.
  *
  * @param {string} systemBaseUri SystemBaseUri for the tenant
  * @param {string} authSessionId Vaild AuthSessionId

--- a/packages/task/src/delete-task/delete-task.ts
+++ b/packages/task/src/delete-task/delete-task.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { NoTaskLocationError, TaskNotFoundError, UnauthenticatedError, UnauthorizedError } from "../errors";
+import { NoTaskLocationError, TaskAlreadyCompletedError, TaskNotFoundError, UnauthenticatedError, UnauthorizedError } from "../errors";
 import { Task } from "../task";
 
 /**
@@ -60,6 +60,8 @@ export async function deleteTask(systemBaseUri: string, authSessionId: string, t
         throw new UnauthorizedError(errorContext, e.response);
       case 404:
         throw new TaskNotFoundError(errorContext, location, e.response);
+      case 410:
+        throw new TaskAlreadyCompletedError(errorContext, location, e.response);
       }
     }
     e.message = `${errorContext}: ${e.message}`;

--- a/packages/task/src/delete-task/delete-task.ts
+++ b/packages/task/src/delete-task/delete-task.ts
@@ -3,31 +3,29 @@ import { NoTaskLocationError, TaskAlreadyCompletedError, TaskNotFoundError, Unau
 import { Task } from "../task";
 
 /**
- * Delete a [Task]{@link Task}.
- *
- *
- * @throws [[NoTaskLocationError]] indicates that no location was given.
- * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
- * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
- * @throws [[TaskNotFoundError]] indicates that for the given location no task was found.
- * @throws [[TaskAlreadyCompleted]] indicates that a task is already marked as completed.
+ * Delete a {@link Task}.
  *
  * @param {string} systemBaseUri SystemBaseUri for the tenant
  * @param {string} authSessionId Vaild AuthSessionId
- * @param {string|Task} task Location of a task or the [Task]{@link Task} itself
+ * @param {string|Task} task Location of the task or the {@link Task}
+ *
+ * @throws {@link NoTaskLocationError} indicates that no location was given.
+ * @throws {@link UnauthenticatedError} indicates that the authSessionId was invalid or expired.
+ * @throws {@link UnauthorizedError} indicates that the user associated with the authSessionId does miss permissions.
+ * @throws {@link TaskNotFoundError} indicates that for the given location no task was found.
+ * @throws {@link TaskAlreadyCompletedError} indicates that a task is already marked as completed.
  *
  * @example ```typescript
- * const taskLocation: string = "/some/task/location";
- * await deleteTask("https://umbrella-corp.d-velop.cloud", "AUTH_SESSION_ID", taskLocation);
+ *
+ * await deleteTask("https://umbrella-corp.d-velop.cloud", "AUTH_SESSION_ID", "/some/task/location");
  *
  * // or
  *
  * const task: Task = {
- *   location: "/some/task/location",
+ *     location: "/some/task/location",
  *   ...
  * }
  * await deleteTask("https://umbrella-corp.d-velop.cloud", "AUTH_SESSION_ID", task);
- *
  * ```
  */
 

--- a/packages/task/src/delete-task/delete-task.ts
+++ b/packages/task/src/delete-task/delete-task.ts
@@ -1,8 +1,16 @@
 import axios from "axios";
+import { NoTaskLocationError, TaskNotFoundError, UnauthenticatedError, UnauthorizedError } from "../errors";
 import { Task } from "../task";
 
 /**
  * Delete a [Task]{@link Task}.
+ *
+ *
+ * @throws [[NoTaskLocationError]] indicates that no location was given.
+ * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
+ * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
+ * @throws [[TaskNotFoundError]] indicates that for the given location no task was found.
+ *
  * @param {string} systemBaseUri SystemBaseUri for the tenant
  * @param {string} authSessionId Vaild AuthSessionId
  * @param {string|Task} task Location of a task or the [Task]{@link Task} itself
@@ -24,6 +32,7 @@ import { Task } from "../task";
 
 export async function deleteTask(systemBaseUri: string, authSessionId: string, task: string | Task): Promise<void> {
 
+  const context: string = "Failed to delete task";
   let location: string;
 
   if (task && typeof task === "string") {
@@ -31,11 +40,12 @@ export async function deleteTask(systemBaseUri: string, authSessionId: string, t
   } else if (task && (task as Task).location) {
     location = (task as Task).location!;
   } else {
-    throw new Error("Failed to delete Task.\nNo Location");
+    throw new NoTaskLocationError(context, task);
   }
 
   try {
-    await axios.delete(`${systemBaseUri}${location}`, {
+    await axios.delete(location, {
+      baseURL: systemBaseUri,
       headers: {
         "Authorization": `Bearer ${authSessionId}`,
         "Origin": systemBaseUri
@@ -45,13 +55,14 @@ export async function deleteTask(systemBaseUri: string, authSessionId: string, t
     if (e.response) {
       switch (e.response.status) {
       case 401:
-        throw new Error("The user is not authenticated.");
+        throw new UnauthenticatedError(context, e.response);
       case 403:
-        throw new Error("The user does not have the permission to delete this task.");
+        throw new UnauthorizedError(context, e.response);
       case 404:
-        throw new Error("The task does not exist.");
+        throw new TaskNotFoundError(context, location, e.response);
       }
     }
-    throw new Error(`Failed to delete Task: ${JSON.stringify(e)}`);
+    e.message = `${context}: ${e.message}`;
+    throw e;
   }
 }

--- a/packages/task/src/errors.ts
+++ b/packages/task/src/errors.ts
@@ -1,4 +1,5 @@
 import { AxiosResponse } from "axios";
+import { Task } from "./task";
 
 /**
  *
@@ -21,5 +22,29 @@ export class UnauthorizedUserError extends Error {
   constructor(context: string, public response: AxiosResponse) {
     super(`${context}: User is not eligible.`);
     Object.setPrototypeOf(this, UnauthorizedUserError.prototype);
+  }
+}
+
+/**
+ *
+ * @category Error
+ */
+export class NoTaskLocationError extends Error {
+// eslint-disable-next-line no-unused-vars
+  constructor(context: string, public task: string | Task) {
+    super(`${context}: No location given for task.`);
+    Object.setPrototypeOf(this, NoTaskLocationError.prototype);
+  }
+}
+
+/**
+ *
+ * @category Error
+ */
+export class TaskNoFoundError extends Error {
+// eslint-disable-next-line no-unused-vars
+  constructor(context: string, public location: string, public response: AxiosResponse) {
+    super(`${context}: Task does not exist at location: '${location}'.`);
+    Object.setPrototypeOf(this, TaskNoFoundError.prototype);
   }
 }

--- a/packages/task/src/errors.ts
+++ b/packages/task/src/errors.ts
@@ -5,11 +5,11 @@ import { Task } from "./task";
  *
  * @category Error
  */
-export class UnauthenticatedUserError extends Error {
+export class UnauthenticatedError extends Error {
 // eslint-disable-next-line no-unused-vars
   constructor(context: string, public response: AxiosResponse) {
     super(`${context}: Unauthenticated User.`);
-    Object.setPrototypeOf(this, UnauthenticatedUserError.prototype);
+    Object.setPrototypeOf(this, UnauthenticatedError.prototype);
   }
 }
 
@@ -17,11 +17,11 @@ export class UnauthenticatedUserError extends Error {
  *
  * @category Error
  */
-export class UnauthorizedUserError extends Error {
+export class UnauthorizedError extends Error {
 // eslint-disable-next-line no-unused-vars
   constructor(context: string, public response: AxiosResponse) {
     super(`${context}: User is not eligible.`);
-    Object.setPrototypeOf(this, UnauthorizedUserError.prototype);
+    Object.setPrototypeOf(this, UnauthorizedError.prototype);
   }
 }
 
@@ -41,10 +41,10 @@ export class NoTaskLocationError extends Error {
  *
  * @category Error
  */
-export class TaskNoFoundError extends Error {
+export class TaskNotFoundError extends Error {
 // eslint-disable-next-line no-unused-vars
   constructor(context: string, public location: string, public response: AxiosResponse) {
     super(`${context}: Task does not exist at location: '${location}'.`);
-    Object.setPrototypeOf(this, TaskNoFoundError.prototype);
+    Object.setPrototypeOf(this, TaskNotFoundError.prototype);
   }
 }

--- a/packages/task/src/errors.ts
+++ b/packages/task/src/errors.ts
@@ -1,12 +1,25 @@
 import { AxiosResponse } from "axios";
 import { Task } from "./task";
 
+
 /**
- *
+ * A given task was invalid. See ```validation```-propery.
+ * @category Error
+ */
+export class InvalidTaskError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(context: string, public task: Task, public validation: any, public response: AxiosResponse) {
+    super(`${context}: Task was invalid. Validation: ${JSON.stringify(validation)} `);
+    Object.setPrototypeOf(this, InvalidTaskError.prototype);
+  }
+}
+
+/**
+ * An authSessionId was invalid or expired.
  * @category Error
  */
 export class UnauthenticatedError extends Error {
-// eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line no-unused-vars
   constructor(context: string, public response: AxiosResponse) {
     super(`${context}: Unauthenticated User.`);
     Object.setPrototypeOf(this, UnauthenticatedError.prototype);
@@ -14,11 +27,11 @@ export class UnauthenticatedError extends Error {
 }
 
 /**
- *
+ * AuthSessionId is associated with a user who is not eligible.
  * @category Error
  */
 export class UnauthorizedError extends Error {
-// eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line no-unused-vars
   constructor(context: string, public response: AxiosResponse) {
     super(`${context}: User is not eligible.`);
     Object.setPrototypeOf(this, UnauthorizedError.prototype);
@@ -26,11 +39,11 @@ export class UnauthorizedError extends Error {
 }
 
 /**
- *
+ * No location was given.
  * @category Error
  */
 export class NoTaskLocationError extends Error {
-// eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line no-unused-vars
   constructor(context: string, public task: string | Task) {
     super(`${context}: No location given for task.`);
     Object.setPrototypeOf(this, NoTaskLocationError.prototype);
@@ -38,13 +51,25 @@ export class NoTaskLocationError extends Error {
 }
 
 /**
- *
+ * Task does not exist at given location.
  * @category Error
  */
 export class TaskNotFoundError extends Error {
-// eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line no-unused-vars
   constructor(context: string, public location: string, public response: AxiosResponse) {
     super(`${context}: Task does not exist at location: '${location}'.`);
     Object.setPrototypeOf(this, TaskNotFoundError.prototype);
+  }
+}
+
+/**
+ * Tried to complete a Task which was already completed.
+ * @category Error
+ */
+export class TaskAlreadyCompletedError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(context: string, public location: string, public response: AxiosResponse) {
+    super(`${context}: Task was already completed at location: ${location} `);
+    Object.setPrototypeOf(this, TaskAlreadyCompletedError.prototype);
   }
 }

--- a/packages/task/src/errors.ts
+++ b/packages/task/src/errors.ts
@@ -1,0 +1,25 @@
+import { AxiosResponse } from "axios";
+
+/**
+ *
+ * @category Error
+ */
+export class UnauthenticatedUserError extends Error {
+// eslint-disable-next-line no-unused-vars
+  constructor(context: string, public response: AxiosResponse) {
+    super(`${context}: Unauthenticated User.`);
+    Object.setPrototypeOf(this, UnauthenticatedUserError.prototype);
+  }
+}
+
+/**
+ *
+ * @category Error
+ */
+export class UnauthorizedUserError extends Error {
+// eslint-disable-next-line no-unused-vars
+  constructor(context: string, public response: AxiosResponse) {
+    super(`${context}: User is not eligible.`);
+    Object.setPrototypeOf(this, UnauthorizedUserError.prototype);
+  }
+}

--- a/packages/task/src/index.ts
+++ b/packages/task/src/index.ts
@@ -23,8 +23,8 @@
  * @module task
  */
 export { Task, TaskContext, TaskMetaData, TaskLinks } from "./task";
-export { UnauthenticatedError, UnauthorizedError, NoTaskLocationError, TaskNotFoundError } from "./errors";
-export { createTask, InvalidTaskError } from "./create-task/create-task";
-export { completeTask, TaskAlreadyCompletedError } from "./complete-task/complete-task";
+export { InvalidTaskError, UnauthenticatedError, UnauthorizedError, NoTaskLocationError, TaskNotFoundError, TaskAlreadyCompletedError } from "./errors";
+export { createTask } from "./create-task/create-task";
+export { completeTask } from "./complete-task/complete-task";
 export { deleteTask } from "./delete-task/delete-task";
 export { updateTask } from "./update-task/update-task";

--- a/packages/task/src/index.ts
+++ b/packages/task/src/index.ts
@@ -22,8 +22,9 @@
  * </div>
  * @module task
  */
-export { createTask } from "./create-task/create-task";
-export { completeTask } from "./complete-task/complete-task";
+export { Task, TaskContext, TaskMetaData, TaskLinks } from "./task";
+export { UnauthenticatedError, UnauthorizedError, NoTaskLocationError, TaskNotFoundError } from "./errors";
+export { createTask, InvalidTaskError } from "./create-task/create-task";
+export { completeTask, TaskAlreadyCompletedError } from "./complete-task/complete-task";
 export { deleteTask } from "./delete-task/delete-task";
 export { updateTask } from "./update-task/update-task";
-export { Task, TaskContext, TaskMetaData, TaskLinks } from "./task";

--- a/packages/task/src/update-task/update-task.ts
+++ b/packages/task/src/update-task/update-task.ts
@@ -1,8 +1,15 @@
 import axios from "axios";
+import { InvalidTaskError, NoTaskLocationError, TaskAlreadyCompletedError, TaskNotFoundError, UnauthenticatedError, UnauthorizedError } from "../errors";
 import { Task } from "../task";
 
 /**
  * Update an existing [Task]{@link Task}.
+ *
+ * @throws [[NoTaskLocationError]] indicates that no location was given.
+ * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
+ * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
+ * @throws [[TaskNotFoundError]] indicates that for the given location no task was found.
+ * @throws [[TaskAlreadyCompleted]] indicates that a task is already marked as completed.
  *
  * @param {string} systemBaseUri SystemBaseUri for the tenant.
  * @param {string} authSessionId Vaild AuthSessionId
@@ -16,12 +23,18 @@ import { Task } from "../task";
 
 export async function updateTask(systemBaseUri: string, authSessionId: string, task: Task,): Promise<void> {
 
-  if (!task.location) {
-    throw new Error("Failed to update Task.\nNo Location");
+  const errorContext: string = "Failed to update task";
+  let location: string;
+
+  if (task.location) {
+    location = task.location;
+  } else {
+    throw new NoTaskLocationError(errorContext, task);
   }
 
   try {
-    await axios.patch(`${systemBaseUri}${task.location}`, task, {
+    await axios.patch(location, task, {
+      baseURL: systemBaseUri,
       headers: {
         "Authorization": `Bearer ${authSessionId}`,
         "Origin": systemBaseUri
@@ -30,16 +43,19 @@ export async function updateTask(systemBaseUri: string, authSessionId: string, t
   } catch (e) {
     if (e.response) {
       switch (e.response.status) {
+      case 400:
+        throw new InvalidTaskError(errorContext, task, e.response.data, e.response);
       case 401:
-        throw new Error("The user is not authenticated.");
+        throw new UnauthenticatedError(errorContext, e.response);
       case 403:
-        throw new Error("The user does not have the permission to update this task.");
+        throw new UnauthorizedError(errorContext, e.response);
       case 404:
-        throw new Error("The task does not exist.");
+        throw new TaskNotFoundError(errorContext, location, e.response);
       case 410:
-        throw new Error("This task was already completed.");
+        throw new TaskAlreadyCompletedError(errorContext, location, e.response);
       }
     }
-    throw new Error(`Failed to update Task: ${JSON.stringify(e)}`);
+    e.message = `${errorContext}: ${e.message}`;
+    throw e;
   }
 }

--- a/packages/task/src/update-task/update-task.ts
+++ b/packages/task/src/update-task/update-task.ts
@@ -3,26 +3,32 @@ import { InvalidTaskError, NoTaskLocationError, TaskAlreadyCompletedError, TaskN
 import { Task } from "../task";
 
 /**
- * Update an existing [Task]{@link Task}.
+ * Update an existing {@link Task}.
  *
- * @throws [[NoTaskLocationError]] indicates that no location was given.
- * @throws [[InvalidTaskError]] indicates that the given task was not accepted because it is invalid. You can check the ```error.validation```-property.
- * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
- * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
- * @throws [[TaskNotFoundError]] indicates that for the given location no task was found.
- * @throws [[TaskAlreadyCompleted]] indicates that a task is already marked as completed.
- *
- * @param {string} systemBaseUri SystemBaseUri for the tenant.
+ * @param {string} systemBaseUri SystemBaseUri for the tenant
  * @param {string} authSessionId Vaild AuthSessionId
- * @param {Task} task Task object with values to be updated.
+ * @param {Task} task {@link Task} with updated values
+ * @returns {Task} Updated {@link Task}
+ *
+ * @throws {@link NoTaskLocationError} indicates that no location was given.
+ * @throws {@link InvalidTaskError} indicates that the given task was not accepted because it is invalid. You can check the ```error.validation```-property.
+ * @throws {@link UnauthenticatedError} indicates that the authSessionId was invalid or expired.
+ * @throws {@link UnauthorizedError} indicates that the user associated with the authSessionId does miss permissions.
+ * @throws {@link TaskNotFoundError} indicates that for the given location no task was found.
+ * @throws {@link TaskAlreadyCompletedError} indicates that a task is already marked as completed.
  *
  * @example ```typescript
- * task.description = "Try harder! Bribe some people if u must."
+ *
+ * const task: Task = {
+ *   ...
+ *   description: "Try harder! Bribe some people if you must."
+ * }
+ *
  * await updateTask("https://umbrella-corp.d-velop.cloud", "AUTH_SESSION_ID", task);
  * ```
  */
 
-export async function updateTask(systemBaseUri: string, authSessionId: string, task: Task,): Promise<void> {
+export async function updateTask(systemBaseUri: string, authSessionId: string, task: Task,): Promise<Task> {
 
   const errorContext: string = "Failed to update task";
   let location: string;
@@ -41,6 +47,7 @@ export async function updateTask(systemBaseUri: string, authSessionId: string, t
         "Origin": systemBaseUri
       },
     });
+    return task;
   } catch (e) {
     if (e.response) {
       switch (e.response.status) {

--- a/packages/task/src/update-task/update-task.ts
+++ b/packages/task/src/update-task/update-task.ts
@@ -6,6 +6,7 @@ import { Task } from "../task";
  * Update an existing [Task]{@link Task}.
  *
  * @throws [[NoTaskLocationError]] indicates that no location was given.
+ * @throws [[InvalidTaskError]] indicates that the given task was not accepted because it is invalid. You can check the ```error.validation```-property.
  * @throws [[UnauthenticatedError]] indicates that the authSessionId was invalid or expired.
  * @throws [[UnauthorizedError]] indicates that the user associated with the authSessionId does miss permissions.
  * @throws [[TaskNotFoundError]] indicates that for the given location no task was found.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,13 @@
       "path": "./packages/app-router",
     },
     {
+      "path": "./packages/axios-hal-json"
+    },
+    {
       "path": "./packages/identityprovider"
     },
     {
       "path": "./packages/task"
-    },
+    }
   ]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,7 @@
 {
     "entryPoints": [
         "packages/app-router/src/index.ts",
+        "packages/axios-hal-json/src/index.ts",
         "packages/identityprovider/src/index.ts",
         "packages/task/src/index.ts"
     ],


### PR DESCRIPTION
Implementing axios-hal-json client for ease of use of the d.velop cloud REST API. Fixes #28

- [x] Implement function that can be registered as an axios-interceptor and is able to:
  - [x] follow hal-json links
  - [x] template urls along the way
- [x] Change existing http calls
- [x] Fix #22 while at it

