### PR TITLE
Fix license check

### DIFF
--- a/scripts/check-licenses.ts
+++ b/scripts/check-licenses.ts
@@ -8,14 +8,17 @@ import { execSync } from "child_process";
 
   packages.forEach(p => {
     try {
-      execSync(`license-checker --onlyAllow Apache-2.0;MIT;ISC;BSD-2-Clause;BSD-3-Clause --start ./packages/${p} --production`);
+      execSync(`license-checker --onlyAllow "Apache-2.0;MIT;ISC;BSD-2-Clause;BSD-3-Clause" --start ./packages/${p} --production`);
+      console.log(`License check successful in package '${p}'`);
     } catch (e) {
-      console.error(`License check unsuccessful in '${p}': ${e}`);
+      console.error(`License check unsuccessful in package '${p}': ${e}`);
       error = true;
     }
   });
 
   if(error) {
     throw "License check unsuccessful";
+  } else {
+	  console.log("License check successful");
   }
 })();


### PR DESCRIPTION
Ubuntu treats semicolons as end of command. Fixed by adding quotes. Fixes #33 