### PR TITLE
Fix bug: Bump core version in express-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6846,30 +6846,12 @@
         "@dvelop-sdk/core": "^2.0.0"
       }
     },
-    "packages/app-router/node_modules/@dvelop-sdk/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@dvelop-sdk/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-GZbeg1qzOp5xFtkxt14PZ6mJb3nf7p/RGecj0CPXuDN+aHhgS96xgHhKG7SzNrtd2xzC1foJpctuaRzteIet4Q==",
-      "dependencies": {
-        "axios": "^0.23.0",
-        "uuid": "^8.3.2"
-      }
-    },
     "packages/business-objects": {
       "name": "@dvelop-sdk/business-objects",
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dvelop-sdk/core": "^2.0.0"
-      }
-    },
-    "packages/business-objects/node_modules/@dvelop-sdk/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@dvelop-sdk/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-GZbeg1qzOp5xFtkxt14PZ6mJb3nf7p/RGecj0CPXuDN+aHhgS96xgHhKG7SzNrtd2xzC1foJpctuaRzteIet4Q==",
-      "dependencies": {
-        "axios": "^0.23.0",
-        "uuid": "^8.3.2"
       }
     },
     "packages/core": {
@@ -6886,19 +6868,10 @@
     },
     "packages/dms": {
       "name": "@dvelop-sdk/dms",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dvelop-sdk/core": "^2.0.0"
-      }
-    },
-    "packages/dms/node_modules/@dvelop-sdk/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@dvelop-sdk/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-GZbeg1qzOp5xFtkxt14PZ6mJb3nf7p/RGecj0CPXuDN+aHhgS96xgHhKG7SzNrtd2xzC1foJpctuaRzteIet4Q==",
-      "dependencies": {
-        "axios": "^0.23.0",
-        "uuid": "^8.3.2"
+        "@dvelop-sdk/core": "^2.1.0"
       }
     },
     "packages/express-utils": {
@@ -6907,7 +6880,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dvelop-sdk/app-router": "^3.2.1",
-        "@dvelop-sdk/core": "^2.0.0",
+        "@dvelop-sdk/core": "^2.1.0",
         "@dvelop-sdk/identityprovider": "^4.0.2",
         "@types/express": "^4.17.13"
       }
@@ -6934,15 +6907,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dvelop-sdk/core": "^2.0.0"
-      }
-    },
-    "packages/task/node_modules/@dvelop-sdk/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@dvelop-sdk/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-GZbeg1qzOp5xFtkxt14PZ6mJb3nf7p/RGecj0CPXuDN+aHhgS96xgHhKG7SzNrtd2xzC1foJpctuaRzteIet4Q==",
-      "dependencies": {
-        "axios": "^0.23.0",
-        "uuid": "^8.3.2"
       }
     }
   },
@@ -7267,34 +7231,12 @@
       "version": "file:packages/app-router",
       "requires": {
         "@dvelop-sdk/core": "^2.0.0"
-      },
-      "dependencies": {
-        "@dvelop-sdk/core": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@dvelop-sdk/core/-/core-2.0.1.tgz",
-          "integrity": "sha512-GZbeg1qzOp5xFtkxt14PZ6mJb3nf7p/RGecj0CPXuDN+aHhgS96xgHhKG7SzNrtd2xzC1foJpctuaRzteIet4Q==",
-          "requires": {
-            "axios": "^0.23.0",
-            "uuid": "^8.3.2"
-          }
-        }
       }
     },
     "@dvelop-sdk/business-objects": {
       "version": "file:packages/business-objects",
       "requires": {
         "@dvelop-sdk/core": "^2.0.0"
-      },
-      "dependencies": {
-        "@dvelop-sdk/core": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@dvelop-sdk/core/-/core-2.0.1.tgz",
-          "integrity": "sha512-GZbeg1qzOp5xFtkxt14PZ6mJb3nf7p/RGecj0CPXuDN+aHhgS96xgHhKG7SzNrtd2xzC1foJpctuaRzteIet4Q==",
-          "requires": {
-            "axios": "^0.23.0",
-            "uuid": "^8.3.2"
-          }
-        }
       }
     },
     "@dvelop-sdk/core": {
@@ -7308,25 +7250,14 @@
     "@dvelop-sdk/dms": {
       "version": "file:packages/dms",
       "requires": {
-        "@dvelop-sdk/core": "^2.0.0"
-      },
-      "dependencies": {
-        "@dvelop-sdk/core": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@dvelop-sdk/core/-/core-2.0.1.tgz",
-          "integrity": "sha512-GZbeg1qzOp5xFtkxt14PZ6mJb3nf7p/RGecj0CPXuDN+aHhgS96xgHhKG7SzNrtd2xzC1foJpctuaRzteIet4Q==",
-          "requires": {
-            "axios": "^0.23.0",
-            "uuid": "^8.3.2"
-          }
-        }
+        "@dvelop-sdk/core": "^2.1.0"
       }
     },
     "@dvelop-sdk/express-utils": {
       "version": "file:packages/express-utils",
       "requires": {
         "@dvelop-sdk/app-router": "^3.2.1",
-        "@dvelop-sdk/core": "^2.0.0",
+        "@dvelop-sdk/core": "^2.1.0",
         "@dvelop-sdk/identityprovider": "^4.0.2",
         "@types/express": "^4.17.13"
       }
@@ -7347,17 +7278,6 @@
       "version": "file:packages/task",
       "requires": {
         "@dvelop-sdk/core": "^2.0.0"
-      },
-      "dependencies": {
-        "@dvelop-sdk/core": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@dvelop-sdk/core/-/core-2.0.1.tgz",
-          "integrity": "sha512-GZbeg1qzOp5xFtkxt14PZ6mJb3nf7p/RGecj0CPXuDN+aHhgS96xgHhKG7SzNrtd2xzC1foJpctuaRzteIet4Q==",
-          "requires": {
-            "axios": "^0.23.0",
-            "uuid": "^8.3.2"
-          }
-        }
       }
     },
     "@eslint/eslintrc": {

--- a/packages/express-utils/package.json
+++ b/packages/express-utils/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@dvelop-sdk/app-router": "^3.2.1",
-    "@dvelop-sdk/core": "^2.0.0",
+    "@dvelop-sdk/core": "^2.1.0",
     "@dvelop-sdk/identityprovider": "^4.0.2",
     "@types/express": "^4.17.13"
   }


### PR DESCRIPTION
`TypeError: name argument is required to req.get` was thrown since core@2.0.0 had no reference of "TRACEPARENT_HEADER"-string
