### PR TITLE
releaseAndUpdate-function

### DIFF
--- a/packages/dms/src/dms-objects/release-and-update-dms-objects/release-and-update-dms-objects.spec.ts
+++ b/packages/dms/src/dms-objects/release-and-update-dms-objects/release-and-update-dms-objects.spec.ts
@@ -1,0 +1,160 @@
+import { DvelopContext, UpdateDmsObjectParams, DmsObject } from "../../index";
+import { _releaseAndUpdateDmsObjectFactory, ReleaseAndUpdateDmsObjectError } from "./release-and-update-dms-objects";
+
+describe("updateDmsObject", () => {
+
+  const mockGetDmsObject = jest.fn();
+  const mockUpdateDmsObjectStatus = jest.fn();
+  const mockUpdateDmsObject = jest.fn();
+
+  let dmsObject: DmsObject;
+  let context: DvelopContext;
+  let params: UpdateDmsObjectParams;
+
+  beforeEach(() => {
+
+    jest.resetAllMocks();
+
+    dmsObject = {
+      repositoryId: "someRepoId",
+      sourceId: "hiItsMeSourceId",
+      dmsObjectId: "hiItsMeDmsObjectId",
+      categories: ["hiItsMeCategoryId"],
+      properties: [{
+        key: "property_state",
+        value: "HiItsMeStatus"
+      }, {
+        key: "hiItsMeProperty",
+        value: "hiItsMePropertyValue"
+      }]
+    };
+
+    context = {
+      systemBaseUri: "HiItsMeSystemBaseUri"
+    };
+
+    params = {
+      repositoryId: "HiItsMeRepositoryId",
+      sourceId: "HiItsMeSourceId",
+      dmsObjectId: "HiItsMeDmsObjectId",
+      alterationText: "HiItsMeAlterationText",
+    };
+  });
+
+  it("should call getDmsObject correctly", async () => {
+
+    mockGetDmsObject.mockResolvedValue(dmsObject);
+
+    const releaseAndUpdateDmsObject = _releaseAndUpdateDmsObjectFactory(mockGetDmsObject, mockUpdateDmsObjectStatus, mockUpdateDmsObject);
+    await releaseAndUpdateDmsObject(context, params);
+
+    expect(mockGetDmsObject).toHaveBeenCalledTimes(1);
+    expect(mockGetDmsObject).toHaveBeenCalledWith(context, {
+      repositoryId: params.repositoryId,
+      dmsObjectId: params.dmsObjectId,
+      sourceId: params.sourceId
+    });
+
+  });
+
+  it("should call updateDmsObjectStatus correctly if state is not 'Released'", async () => {
+
+    mockGetDmsObject.mockResolvedValue(dmsObject);
+
+    const releaseAndUpdateDmsObject = _releaseAndUpdateDmsObjectFactory(mockGetDmsObject, mockUpdateDmsObjectStatus, mockUpdateDmsObject);
+    await releaseAndUpdateDmsObject(context, params);
+
+    expect(mockUpdateDmsObjectStatus).toHaveBeenCalledTimes(1);
+    expect(mockUpdateDmsObjectStatus).toHaveBeenCalledWith(context, {
+      repositoryId: params.repositoryId,
+      dmsObjectId: params.dmsObjectId,
+      status: "Release",
+      alterationText: params.alterationText
+    });
+  });
+
+
+  it("should not call updateDmsObjectStatus if state is 'Released'", async () => {
+
+    mockGetDmsObject.mockResolvedValue({
+      ...dmsObject,
+      ...{
+        properties: [
+          {
+            key: "property_state",
+            value: "Released"
+          }
+        ]
+      }
+    });
+
+    const releaseAndUpdateDmsObject = _releaseAndUpdateDmsObjectFactory(mockGetDmsObject, mockUpdateDmsObjectStatus, mockUpdateDmsObject);
+    await releaseAndUpdateDmsObject(context, params);
+
+    expect(mockUpdateDmsObjectStatus).toHaveBeenCalledTimes(0);
+  });
+
+
+
+  it("should call updateDmsObject correctly", async () => {
+
+    mockGetDmsObject.mockResolvedValue(dmsObject);
+
+    const releaseAndUpdateDmsObject = _releaseAndUpdateDmsObjectFactory(mockGetDmsObject, mockUpdateDmsObjectStatus, mockUpdateDmsObject);
+    await releaseAndUpdateDmsObject(context, params);
+
+    expect(mockUpdateDmsObject).toHaveBeenCalledTimes(1);
+    expect(mockUpdateDmsObject).toHaveBeenCalledWith(context, params)
+  });
+
+  describe("handle no state", () => {
+
+    [
+      {
+        repositoryId: "someRepoId",
+        sourceId: "hiItsMeSourceId",
+        dmsObjectId: "hiItsMeDmsObjectId",
+        categories: ["hiItsMeCategoryId"]
+      }, {
+        repositoryId: "someRepoId",
+        sourceId: "hiItsMeSourceId",
+        dmsObjectId: "hiItsMeDmsObjectId",
+        categories: ["hiItsMeCategoryId"],
+        properties: [
+          {
+            key: "hiItsMePropertyKey",
+            value: "hiItsMePropertyKey"
+          }
+        ]
+      }, {
+        repositoryId: "someRepoId",
+        sourceId: "hiItsMeSourceId",
+        dmsObjectId: "hiItsMeDmsObjectId",
+        categories: ["hiItsMeCategoryId"],
+        properties: [
+          {
+            key: "property_state"
+          }
+        ]
+      }
+
+    ].forEach(testCase => {
+      it("should throw ReleaseAndUpdateDmsObjectError on no state", async () => {
+
+        mockGetDmsObject.mockResolvedValue(testCase);
+
+        const releaseAndUpdateDmsObject = _releaseAndUpdateDmsObjectFactory(mockGetDmsObject, mockUpdateDmsObjectStatus, mockUpdateDmsObject);
+
+        let expectedError: any;
+        try {
+          await releaseAndUpdateDmsObject(context, params);
+        } catch (error: any) {
+          expectedError = error;
+        }
+
+        expect(expectedError instanceof ReleaseAndUpdateDmsObjectError).toBeTruthy();
+        expect(expectedError.message).toContain("State of DmsObject could not be determined.");
+      });
+    });
+  });
+});

--- a/packages/dms/src/dms-objects/release-and-update-dms-objects/release-and-update-dms-objects.ts
+++ b/packages/dms/src/dms-objects/release-and-update-dms-objects/release-and-update-dms-objects.ts
@@ -1,0 +1,94 @@
+import { BadInputError, DvelopContext } from "@dvelop-sdk/core";
+import { getDmsObject, GetDmsObjectParams, DmsObject, updateDmsObjectStatus, UpdateDmsObjectStatusParams, updateDmsObject, UpdateDmsObjectParams } from "../../index";
+import { _defaultHttpRequestFunction, _getDmsObjectFactory, _getDmsObjectDefaultTransformFunctionFactory, _updateDmsObjectDefaultTransformFunction } from "../../internal";
+
+/**
+* This error indicates a problem with reading the DmsObject. Do you have all relevant permissions?
+* @category Error
+*/
+export class ReleaseAndUpdateDmsObjectError extends Error {
+  // eslint-disable-next-line no-unused-vars
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, ReleaseAndUpdateDmsObjectError.prototype);
+  }
+}
+
+/**
+ * Factory for the {@link releaseAndUpdateDmsObject}-function. This is a wrapper around {@link getDmsObject}, {@link updateDmsObjectStatus} and {@link updateDmsObject} combined.
+ * @internal
+ * @category DmsObject
+ */
+export function _releaseAndUpdateDmsObjectFactory(
+  getDmsObjectsFunction: (context: DvelopContext, params: GetDmsObjectParams) => Promise<DmsObject>,
+  updateDmsObjectStatusFunction: (context: DvelopContext, params: UpdateDmsObjectStatusParams) => Promise<void>,
+  updateDmsObjectFunction: (context: DvelopContext, params: UpdateDmsObjectParams) => Promise<void>,
+): (context: DvelopContext, params: UpdateDmsObjectParams) => Promise<void> {
+
+  return async (context: DvelopContext, params: UpdateDmsObjectParams) => {
+
+    const dmsObject: DmsObject = await getDmsObjectsFunction(context, {
+      repositoryId: params.repositoryId,
+      dmsObjectId: params.dmsObjectId,
+      sourceId: params.sourceId
+    });
+
+    const state: string | undefined = dmsObject.properties?.find(p => p.key === "property_state")?.value;
+
+    if (!state) {
+      throw new ReleaseAndUpdateDmsObjectError("State of DmsObject could not be determined.")
+    } else if (state !== "Released") {
+      await updateDmsObjectStatusFunction(context, {
+        repositoryId: params.repositoryId,
+        dmsObjectId: params.dmsObjectId,
+        status: "Release",
+        alterationText: params.alterationText
+      });
+    }
+
+    return updateDmsObjectFunction(context, params);
+  }
+}
+
+/**
+ * Release a DmsObject and update it. This is a variation of {@link updateDmsObject} which has the same syntax.
+ *
+ * Internally this this is a wrapper around {@link getDmsObject}, {@link updateDmsObjectStatus} and {@link updateDmsObject}:
+ *   - {@link getDmsObject}
+ *   - if dmsObjects **not** released
+ *     - {@link updateDmsObjectStatus}
+ *   - {@link updateDmsObject}
+ *
+ * ```typescript
+ * import { updateDmsObject } from "@dvelop-sdk/dms";
+ * import { readFileSync } from "fs";
+ *
+ * //only node.js
+ * const file: ArrayBuffer = readFileSync(`${ __dirname }/our-profits.kaching`).buffer;
+ *
+ * await updateDmsObject({
+ *   systemBaseUri: "https://steamwheedle-cartel.d-velop.cloud",
+ *   authSessionId: "dQw4w9WgXcQ"
+ * }, {
+ *   repositoryId: "qnydFmqHuVo",
+ *   sourceId: "/dms/r/qnydFmqHuVo/source",
+ *   dmsObjectId: "GDYQ3PJKrT8",
+ *   alterationText: "Updated by SDK",
+ *   properties: [
+ *     {
+ *       key: "AaGK-fj-BAM",
+ *       values: ["paid"]
+ *     }
+ *   ],
+ *   fileName: "our-profits.kaching",
+ *   content: file,
+ *   alterationText: "Released for automatic update"
+ * });
+ * ```
+ *
+ * @category DmsObject
+ */
+/* istanbul ignore next */
+export function releaseAndUpdateDmsObject(context: DvelopContext, params: UpdateDmsObjectParams): Promise<void> {
+  return _releaseAndUpdateDmsObjectFactory(getDmsObject, updateDmsObjectStatus, updateDmsObject)(context, params);
+}

--- a/packages/dms/src/dms-objects/update-dms-object-status/update-dms-object-status.spec.ts
+++ b/packages/dms/src/dms-objects/update-dms-object-status/update-dms-object-status.spec.ts
@@ -2,13 +2,10 @@ import { DvelopContext } from "../../index";
 import { HttpResponse } from "../../utils/http";
 import { _updateDmsObjectStatusDefaultTransformFunction, _updateDmsObjectStatusFactory, UpdateDmsObjectStatusParams } from "./update-dms-object-status";
 
-jest.mock("../store-file-temporarily/store-file-temporarily");
-
 describe("updateDmsObject", () => {
 
   let mockHttpRequestFunction = jest.fn();
   let mockTransformFunction = jest.fn();
-  let mockStoreFileFunction = jest.fn();
 
   let context: DvelopContext;
   let params: UpdateDmsObjectStatusParams;


### PR DESCRIPTION
It's a common usecase to always make sure a DmsObject is released before updating. This function wraps a state-check and a potiantial state-update to release before an update.