### PR TITLE
Add contextMiddlewareFactoryWithFixedSystemBaseUri-function

### DIFF
--- a/packages/express-utils/package.json
+++ b/packages/express-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dvelop-sdk/express-utils",
   "description": "This package contains middleware-functions for the express-framework and d.velop app-building.",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/express-utils/src/middleware/dvelop-context-middleware/dvelop-context-middleware.ts
+++ b/packages/express-utils/src/middleware/dvelop-context-middleware/dvelop-context-middleware.ts
@@ -25,10 +25,10 @@ export function contextMiddlewareFactory(
 
   return (req: Request, _: Response, next: NextFunction) => {
 
-    if (systemBaseUri && tenantId) {
+    if (systemBaseUri) {
       req.dvelopContext = {
         systemBaseUri: systemBaseUri,
-        tenantId: tenantId,
+        tenantId: tenantId || req.header(DVELOP_TENANT_ID_HEADER),
         requestId: req.header(DVELOP_REQUEST_ID_HEADER)
       }
     } else {

--- a/packages/express-utils/src/middleware/dvelop-context-middleware/dvelop-context-middleware.ts
+++ b/packages/express-utils/src/middleware/dvelop-context-middleware/dvelop-context-middleware.ts
@@ -82,9 +82,9 @@ export function contextMiddleware(req: Request, _: Response, next: NextFunction)
  * This is a version with a fixed systemBaseUri, primarily used on premise.
  *
  * ```typescript
- * import { contextMiddleware } from "@dvelop-sdk/express-utils";
+ * import { contextMiddlewareFactoryWithFixedSystemBaseUri } from "@dvelop-sdk/express-utils";
  *
- * app.use(contextMiddleware);
+ * app.use(contextMiddlewareFactoryWithFixedSystemBaseUri("https://my.local.baseuri")); //could optionally supply a tenantId (default: 0)
  *
  * app.use((req: Request, _: Response, next: NextFunction) => {
  *   console.log(req.dvelopContext);


### PR DESCRIPTION
In some scenarios (primarily on premise) a fixed systemBaseUri is used. The `contextMiddlewareFactoryWithFixedSystemBaseUri`-function is an alternative to the common `contextMiddleware'-function to accommodate this.

Fixes #200 